### PR TITLE
Update dependency to allow latest minor version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,5 +14,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile 'com.google.android.gms:play-services-ads:8.3.0'
+    compile 'com.google.android.gms:play-services-ads:8.+'
 }


### PR DESCRIPTION
`react-native-admob` has a conflict if used alongside my own `react-native-google-analytics-bridge` module. 
This is because it specifically tries to compile a previous version of the `play-services` dependency (8.3.0).

See [this issue](https://github.com/idehub/react-native-google-analytics-bridge/issues/31).

I've changed my own module to instead target `8.+` which means every latest minor version (8.x.x).
To avoid conflicts with mine, and other modules, I propose doing the same here.

Resolves: #15