### PR TITLE
Requiring React API from react-native is now deprecated after RN@0.25.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  NativeModules,
   requireNativeComponent,
   View,
 } from 'react-native';
@@ -78,6 +79,6 @@ AdMobBanner.defaultProps = { bannerSize: 'smartBannerPortrait', didFailToReceive
 
 const RNBanner = requireNativeComponent('RNAdMob', AdMobBanner);
 
-const AdMobInterstitial = React.NativeModules['RNAdMobInterstitial'];
+const AdMobInterstitial = NativeModules['RNAdMobInterstitial'];
 
 module.exports = {AdMobBanner,AdMobInterstitial};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, {
+import React from 'react';
+import {
   requireNativeComponent,
   View,
 } from 'react-native';


### PR DESCRIPTION
Requiring React API from react-native is deprecated after RN@0.25.1