### PR TITLE
Multiple dex Error on RN 0.26

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,5 +14,5 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.19.+'
-    compile 'com.google.android.gms:play-services-ads:8.+'
+    compile 'com.google.android.gms:play-services-ads:+'
 }


### PR DESCRIPTION
Cause: com.android.dex.DexException: Multiple dex files define Lcom/google/android/gms/internal/zzr;
I have looked at this https://github.com/geektimecoil/react-native-onesignal/issues/20 and simply added the last version (+)