### PR TITLE
Fix the testDeviceID control in Android interstitial ad module.

### DIFF
--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
@@ -104,7 +104,7 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
           requestAdCallback = callback;
           AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
           if (testDeviceID != null){
-            if (testDeviceID.equals("DEVICE_ID_EMULATOR")) {
+            if (testDeviceID.equals("EMULATOR")) {
               adRequestBuilder = adRequestBuilder.addTestDevice(AdRequest.DEVICE_ID_EMULATOR);
             } else {
               adRequestBuilder = adRequestBuilder.addTestDevice(testDeviceID);


### PR DESCRIPTION
Android native module expect `testDeviceID` to be set as `"DEVICE_ID_EMULATOR"`, I corrected it to `"EMULATOR"` as it is documented.