### PR TITLE
Added PublisherBanner ( DFPBanner [iOS] - PublisherAdView [Android])

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![npm version](https://badge.fury.io/js/react-native-admob.svg)](https://badge.fury.io/js/react-native-admob)
 ## react-native-admob
 
-A react-native module for Google AdMob GADBanner and GADInterstitial (react-native v0.19.0 or newer required).
+A react-native module for Google AdMob GADBanner, DFPBanner and GADInterstitial (react-native v0.19.0 or newer required).
 
 The banner is implemented as a component while the interstitial has an imperative API.
 
@@ -60,7 +60,7 @@ Under `protected List<ReactPackage> getPackages() {`:
 ### Usage
 
 ```javascript
-import { AdMobBanner, AdMobInterstitial } from 'react-native-admob'
+import { AdMobBanner, AdMobInterstitial, PublisherBanner} from 'react-native-admob'
 
 // Display a banner
 <AdMobBanner
@@ -68,6 +68,15 @@ import { AdMobBanner, AdMobInterstitial } from 'react-native-admob'
   adUnitID="your-admob-unit-id"
   testDeviceID="EMULATOR"
   didFailToReceiveAdWithError={this.bannerError} />
+
+// Display a DFP Publisher banner
+<PublisherBanner
+  bannerSize="fullBanner"
+  adUnitID="your-admob-unit-id"
+  testDeviceID="EMULATOR"
+  didFailToReceiveAdWithError={this.bannerError}
+  admobDispatchAppEvent={this.adMobEvent} />
+
 
 // Display an interstitial
 AdMobInterstitial.setAdUnitID('your-admob-unit-id');
@@ -101,14 +110,15 @@ For a full example reference to the [example project](Example).
 ##### Events as function props
 *Corresponding to [Ad lifecycle event callbacks](https://developers.google.com/admob/ios/banner)*
 
-| Prop                                          |
-|-----------------------------------------------|
-|`adViewDidReceiveAd()`                         |
-|`didFailToReceiveAdWithError(errorDescription)`|
-|`adViewWillPresentScreen()`                    |
-|`adViewWillDismissScreen()`                    |
-|`adViewDidDismissScreen()`                     |
-|`adViewWillLeaveApplication()`                 |
+| Prop                                           |
+|------------------------------------------------|
+|`adViewDidReceiveAd()`                          |
+|`didFailToReceiveAdWithError(errorDescription)` |
+|`adViewWillPresentScreen()`                     |
+|`adViewWillDismissScreen()`                     |
+|`adViewDidDismissScreen()`                      |
+|`adViewWillLeaveApplication()`                  |
+|'admobDispatchAppEvent()' [PublisherBanner Only]|
 
 #### AdMobInterstitials
 
@@ -146,3 +156,4 @@ Unfortunately, events are not consistent across iOS and Android. To have one uni
 ### TODO
 - [ ] Support [Ad Targeting](https://developers.google.com/admob/ios/targeting)
 - [ ] Also use interstitial event names for banner
+- [ ] PublisherBanner [DFPBanner/PublisherAdView should be able to accept multiple adSizes. Currently only caters for a single size]

--- a/README.md
+++ b/README.md
@@ -118,7 +118,17 @@ For a full example reference to the [example project](Example).
 |`adViewWillDismissScreen()`                     |
 |`adViewDidDismissScreen()`                      |
 |`adViewWillLeaveApplication()`                  |
-|'admobDispatchAppEvent()' [PublisherBanner Only]|
+
+
+#### PublisherBanner
+
+Same as AdMobBanner, except it has an extra event prop:
+
+|'admobDispatchAppEvent()' |
+
+This handles App events that Admob/DFP can send back to the app.
+More info here: https://developers.google.com/mobile-ads-sdk/docs/dfp/android/banner#ios_app-events
+
 
 #### AdMobInterstitials
 

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import {
+  NativeModules,
+  requireNativeComponent,
+  View,
+  NativeEventEmitter,
+} from 'react-native';
+
+const RNBanner = requireNativeComponent('RNAdMob', PublisherBanner);
+
+export default class PublisherBanner extends React.Component {
+
+  constructor() {
+    super();
+    this.onSizeChange = this.onSizeChange.bind(this);
+    this.state = {
+      style: {},
+    };
+  }
+
+  onSizeChange(event) {
+    const { height, width } = event.nativeEvent;
+    this.setState({ style: { width, height } });
+  }
+
+  render() {
+    const { adUnitID, testDeviceID, bannerSize, style, didFailToReceiveAdWithError } = this.props;
+    return (
+      <View style={this.props.style}>
+        <RNBanner
+          style={this.state.style}
+          onSizeChange={this.onSizeChange.bind(this)}
+          onAdViewDidReceiveAd={this.props.adViewDidReceiveAd}
+          onDidFailToReceiveAdWithError={(event) => didFailToReceiveAdWithError(event.nativeEvent.error)}
+          onAdViewWillPresentScreen={this.props.adViewWillPresentScreen}
+          onAdViewWillDismissScreen={this.props.adViewWillDismissScreen}
+          onAdViewDidDismissScreen={this.props.adViewDidDismissScreen}
+          onAdViewWillLeaveApplication={this.props.adViewWillLeaveApplication}
+          testDeviceID={testDeviceID}
+          adUnitID={adUnitID}
+          bannerSize={bannerSize} />
+      </View>
+    );
+  }
+}
+
+PublisherBanner.propTypes = {
+  style: View.propTypes.style,
+
+  /**
+   * AdMob iOS library banner size constants
+   * (https://developers.google.com/admob/ios/banner)
+   * banner (320x50, Standard Banner for Phones and Tablets)
+   * largeBanner (320x100, Large Banner for Phones and Tablets)
+   * mediumRectangle (300x250, IAB Medium Rectangle for Phones and Tablets)
+   * fullBanner (468x60, IAB Full-Size Banner for Tablets)
+   * leaderboard (728x90, IAB Leaderboard for Tablets)
+   * smartBannerPortrait (Screen width x 32|50|90, Smart Banner for Phones and Tablets)
+   * smartBannerLandscape (Screen width x 32|50|90, Smart Banner for Phones and Tablets)
+   *
+   * banner is default
+   */
+  bannerSize: React.PropTypes.string,
+
+  /**
+   * AdMob ad unit ID
+   */
+  adUnitID: React.PropTypes.string,
+
+  /**
+   * Test device ID
+   */
+  testDeviceID: React.PropTypes.string,
+
+  /**
+   * AdMob iOS library events
+   */
+  adViewDidReceiveAd: React.PropTypes.func,
+  didFailToReceiveAdWithError: React.PropTypes.func,
+  adViewWillPresentScreen: React.PropTypes.func,
+  adViewWillDismissScreen: React.PropTypes.func,
+  adViewDidDismissScreen: React.PropTypes.func,
+  adViewWillLeaveApplication: React.PropTypes.func,
+  ...View.propTypes,
+};
+
+PublisherBanner.defaultProps = { bannerSize: 'smartBannerPortrait', didFailToReceiveAdWithError: () => {} };

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -6,7 +6,7 @@ import {
   NativeEventEmitter,
 } from 'react-native';
 
-const RNBanner = requireNativeComponent('RNAdMob', PublisherBanner);
+const RNBanner = requireNativeComponent('RNAdMobDFP', PublisherBanner);
 
 export default class PublisherBanner extends React.Component {
 
@@ -24,7 +24,7 @@ export default class PublisherBanner extends React.Component {
   }
 
   render() {
-    const { adUnitID, testDeviceID, bannerSize, style, didFailToReceiveAdWithError } = this.props;
+    const { adUnitID, testDeviceID, bannerSize, style, didFailToReceiveAdWithError,admobDispatchAppEvent } = this.props;
     return (
       <View style={this.props.style}>
         <RNBanner
@@ -36,6 +36,7 @@ export default class PublisherBanner extends React.Component {
           onAdViewWillDismissScreen={this.props.adViewWillDismissScreen}
           onAdViewDidDismissScreen={this.props.adViewDidDismissScreen}
           onAdViewWillLeaveApplication={this.props.adViewWillLeaveApplication}
+          onAdmobDispatchAppEvent={(event) => admobDispatchAppEvent(event)}
           testDeviceID={testDeviceID}
           adUnitID={adUnitID}
           bannerSize={bannerSize} />
@@ -81,7 +82,9 @@ PublisherBanner.propTypes = {
   adViewWillDismissScreen: React.PropTypes.func,
   adViewDidDismissScreen: React.PropTypes.func,
   adViewWillLeaveApplication: React.PropTypes.func,
+  admobDispatchAppEvent: React.PropTypes.func,
   ...View.propTypes,
 };
 
-PublisherBanner.defaultProps = { bannerSize: 'smartBannerPortrait', didFailToReceiveAdWithError: () => {} };
+PublisherBanner.defaultProps = { bannerSize: 'smartBannerPortrait', didFailToReceiveAdWithError: () => {} ,
+admobDispatchAppEvent: () => {}};

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobPackage.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobPackage.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +25,9 @@ public class RNAdMobPackage implements ReactPackage {
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
-        return Arrays.<ViewManager>asList(new RNAdMobBannerViewManager());
+        List<ViewManager> managers = new ArrayList<>();
+        managers.add(new RNAdMobBannerViewManager());
+        managers.add(new RNPublisherBannerViewManager());
+        return managers;
     }
 }

--- a/android/src/main/java/com/sbugert/rnadmob/RNPublisherBannerViewManager.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNPublisherBannerViewManager.java
@@ -1,0 +1,233 @@
+package com.sbugert.rnadmob;
+
+import android.support.annotation.Nullable;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.common.MapBuilder;
+import com.facebook.react.uimanager.PixelUtil;
+import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.uimanager.SimpleViewManager;
+import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.views.view.ReactViewGroup;
+import com.google.android.gms.ads.AdListener;
+import com.google.android.gms.ads.doubleclick.PublisherAdRequest;
+import com.google.android.gms.ads.AdSize;
+import com.google.android.gms.ads.AdView;
+import com.google.android.gms.ads.doubleclick.PublisherAdView;
+
+import java.util.Map;
+
+public class RNPublisherBannerViewManager extends SimpleViewManager<ReactViewGroup> {
+
+  public static final String REACT_CLASS = "RNAdMob";
+
+  public static final String PROP_BANNER_SIZE = "bannerSize";
+  public static final String PROP_AD_UNIT_ID = "adUnitID";
+  public static final String PROP_TEST_DEVICE_ID = "testDeviceID";
+
+  private String testDeviceID = null;
+
+  public enum Events {
+    EVENT_SIZE_CHANGE("onSizeChange"),
+    EVENT_RECEIVE_AD("onAdViewDidReceiveAd"),
+    EVENT_ERROR("onDidFailToReceiveAdWithError"),
+    EVENT_WILL_PRESENT("onAdViewWillPresentScreen"),
+    EVENT_WILL_DISMISS("onAdViewWillDismissScreen"),
+    EVENT_DID_DISMISS("onAdViewDidDismissScreen"),
+    EVENT_WILL_LEAVE_APP("onAdViewWillLeaveApplication");
+
+    private final String mName;
+
+    Events(final String name) {
+      mName = name;
+    }
+
+    @Override
+    public String toString() {
+      return mName;
+    }
+  }
+
+  private ThemedReactContext mThemedReactContext;
+  private RCTEventEmitter mEventEmitter;
+
+  @Override
+  public String getName() {
+    return REACT_CLASS;
+  }
+
+  @Override
+  protected ReactViewGroup createViewInstance(ThemedReactContext themedReactContext) {
+    mThemedReactContext = themedReactContext;
+    mEventEmitter = themedReactContext.getJSModule(RCTEventEmitter.class);
+    ReactViewGroup view = new ReactViewGroup(themedReactContext);
+    attachNewAdView(view);
+    return view;
+   }
+
+  protected void attachNewAdView(final ReactViewGroup view) {
+    final PublisherAdView adView = new PublisherAdView(mThemedReactContext);
+
+    // destroy old AdView if present
+    PublisherAdView oldAdView = (PublisherAdView) view.getChildAt(0);
+    view.removeAllViews();
+    if (oldAdView != null) oldAdView.destroy();
+    view.addView(adView);
+    attachEvents(view);
+  }
+
+  protected void attachEvents(final ReactViewGroup view) {
+    final PublisherAdView adView = (PublisherAdView) view.getChildAt(0);
+    adView.setAdListener(new AdListener() {
+      @Override
+      public void onAdLoaded() {
+        int width = adView.getAdSize().getWidthInPixels(mThemedReactContext);
+        int height = adView.getAdSize().getHeightInPixels(mThemedReactContext);
+        int left = adView.getLeft();
+        int top = adView.getTop();
+        adView.measure(width, height);
+        adView.layout(left, top, left + width, top + height);
+        mEventEmitter.receiveEvent(view.getId(), Events.EVENT_RECEIVE_AD.toString(), null);
+      }
+
+      @Override
+      public void onAdFailedToLoad(int errorCode) {
+        WritableMap event = Arguments.createMap();
+        switch (errorCode) {
+          case PublisherAdRequest.ERROR_CODE_INTERNAL_ERROR:
+            event.putString("error", "ERROR_CODE_INTERNAL_ERROR");
+            break;
+          case PublisherAdRequest.ERROR_CODE_INVALID_REQUEST:
+            event.putString("error", "ERROR_CODE_INVALID_REQUEST");
+            break;
+          case PublisherAdRequest.ERROR_CODE_NETWORK_ERROR:
+            event.putString("error", "ERROR_CODE_NETWORK_ERROR");
+            break;
+          case PublisherAdRequest.ERROR_CODE_NO_FILL:
+            event.putString("error", "ERROR_CODE_NO_FILL");
+            break;
+        }
+
+        mEventEmitter.receiveEvent(view.getId(), Events.EVENT_ERROR.toString(), event);
+      }
+
+      @Override
+      public void onAdOpened() {
+        mEventEmitter.receiveEvent(view.getId(), Events.EVENT_WILL_PRESENT.toString(), null);
+      }
+
+      @Override
+      public void onAdClosed() {
+        mEventEmitter.receiveEvent(view.getId(), Events.EVENT_WILL_DISMISS.toString(), null);
+      }
+
+      @Override
+      public void onAdLeftApplication() {
+        mEventEmitter.receiveEvent(view.getId(), Events.EVENT_WILL_LEAVE_APP.toString(), null);
+      }
+    });
+  }
+
+  @Override
+  @Nullable
+  public Map<String, Object> getExportedCustomDirectEventTypeConstants() {
+    MapBuilder.Builder<String, Object> builder = MapBuilder.builder();
+    for (Events event : Events.values()) {
+      builder.put(event.toString(), MapBuilder.of("registrationName", event.toString()));
+    }
+    return builder.build();
+  }
+
+  @ReactProp(name = PROP_BANNER_SIZE)
+  public void setBannerSize(final ReactViewGroup view, final String sizeString) {
+    AdSize adSize = getAdSizeFromString(sizeString);
+    AdSize[] adSizes = new AdSize[1];
+    adSizes[0] = adSize;
+
+    // store old ad unit ID (even if not yet present and thus null)
+    PublisherAdView oldAdView = (PublisherAdView) view.getChildAt(0);
+    String adUnitId = oldAdView.getAdUnitId();
+
+    attachNewAdView(view);
+    PublisherAdView newAdView = (PublisherAdView) view.getChildAt(0);
+    newAdView.setAdSizes(adSizes);
+    newAdView.setAdUnitId(adUnitId);
+
+    // send measurements to js to style the AdView in react
+    int width;
+    int height;
+    WritableMap event = Arguments.createMap();
+    if (adSize == AdSize.SMART_BANNER) {
+      width = (int) PixelUtil.toDIPFromPixel(adSize.getWidthInPixels(mThemedReactContext));
+      height = (int) PixelUtil.toDIPFromPixel(adSize.getHeightInPixels(mThemedReactContext));
+    }
+    else {
+      width = adSize.getWidth();
+      height = adSize.getHeight();
+    }
+    event.putDouble("width", width);
+    event.putDouble("height", height);
+    mEventEmitter.receiveEvent(view.getId(), Events.EVENT_SIZE_CHANGE.toString(), event);
+
+    loadAd(newAdView);
+  }
+
+  @ReactProp(name = PROP_AD_UNIT_ID)
+  public void setAdUnitID(final ReactViewGroup view, final String adUnitID) {
+    // store old banner size (even if not yet present and thus null)
+    PublisherAdView oldAdView = (PublisherAdView) view.getChildAt(0);
+    AdSize[] adSizes = oldAdView.getAdSizes();
+
+    attachNewAdView(view);
+    PublisherAdView newAdView = (PublisherAdView) view.getChildAt(0);
+    newAdView.setAdUnitId(adUnitID);
+    newAdView.setAdSizes(adSizes);
+    loadAd(newAdView);
+  }
+
+  @ReactProp(name = PROP_TEST_DEVICE_ID)
+  public void setPropTestDeviceID(final ReactViewGroup view, final String testDeviceID) {
+    this.testDeviceID = testDeviceID;
+  }
+
+  private void loadAd(final PublisherAdView adView) {
+    if (adView.getAdSizes() != null && adView.getAdUnitId() != null) {
+      PublisherAdRequest.Builder adRequestBuilder = new PublisherAdRequest.Builder();
+      if (testDeviceID != null){
+        if (testDeviceID.equals("EMULATOR")) {
+          adRequestBuilder = adRequestBuilder.addTestDevice(PublisherAdRequest.DEVICE_ID_EMULATOR);
+        } else {
+          adRequestBuilder = adRequestBuilder.addTestDevice(testDeviceID);
+        }
+      }
+      PublisherAdRequest adRequest = adRequestBuilder.build();
+      adView.loadAd(adRequest);
+    }
+  }
+
+
+  private AdSize getAdSizeFromString(String adSize) {
+    switch (adSize) {
+      case "banner":
+        return AdSize.BANNER;
+      case "largeBanner":
+        return AdSize.LARGE_BANNER;
+      case "mediumRectangle":
+        return AdSize.MEDIUM_RECTANGLE;
+      case "fullBanner":
+        return AdSize.FULL_BANNER;
+      case "leaderBoard":
+        return AdSize.LEADERBOARD;
+      case "smartBannerPortrait":
+        return AdSize.SMART_BANNER;
+      case "smartBannerLandscape":
+        return AdSize.SMART_BANNER;
+      case "smartBanner":
+        return AdSize.SMART_BANNER;
+      default:
+        return AdSize.BANNER;
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -4,5 +4,7 @@ import {
 
 import AdMobBanner from './RNAdMobBanner';
 import AdMobInterstitial from './RNAdMobInterstitial';
+import PublisherBanner from './RNPublisherBanner';
 
-module.exports = { AdMobBanner, AdMobInterstitial };
+
+module.exports = { AdMobBanner, AdMobInterstitial ,PublisherBanner};

--- a/ios/RNAdMobDFPManager.h
+++ b/ios/RNAdMobDFPManager.h
@@ -1,0 +1,5 @@
+#import "RCTViewManager.h"
+
+@interface RNAdMobDFPManager : RCTViewManager
+
+@end

--- a/ios/RNAdMobDFPManager.m
+++ b/ios/RNAdMobDFPManager.m
@@ -1,0 +1,42 @@
+#import "RNAdMobDFPManager.h"
+#import "RNDFPBannerView.h"
+
+#import "RCTBridge.h"
+
+@implementation RNAdMobDFPManager
+
+RCT_EXPORT_MODULE();
+
+@synthesize bridge = _bridge;
+
+- (UIView *)view
+{
+  return [[RNDFPBannerView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+}
+
+- (NSArray *) customDirectEventTypes
+{
+  return @[
+           @"onSizeChange",
+           @"onAdViewDidReceiveAd",
+           @"onDidFailToReceiveAdWithError",
+           @"onAdViewWillPresentScreen",
+           @"onAdViewWillDismissScreen",
+           @"onAdViewDidDismissScreen",
+           @"onAdViewWillLeaveApplication",
+           @"onAdmobDispatchAppEvent"
+           ];
+}
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
+
+RCT_EXPORT_VIEW_PROPERTY(bannerSize, NSString);
+RCT_EXPORT_VIEW_PROPERTY(adUnitID, NSString);
+RCT_EXPORT_VIEW_PROPERTY(testDeviceID, NSString);
+
+@end
+

--- a/ios/RNAdMobManager.xcodeproj/project.pbxproj
+++ b/ios/RNAdMobManager.xcodeproj/project.pbxproj
@@ -226,7 +226,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -240,7 +240,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../../react-native/React/**",
+					"$(SRCROOT)/../../../node_modules/react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ios/RNAdMobManager.xcodeproj/project.pbxproj
+++ b/ios/RNAdMobManager.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0CB8C04B1D913E00002BC3EF /* RNDFPBannerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */; };
+		0CB8C04E1D9143A6002BC3EF /* RNAdMobDFPManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8C04D1D9143A6002BC3EF /* RNAdMobDFPManager.m */; };
 		A962C2531CB27DBD00E508A1 /* RNAdMobInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = A962C2521CB27DBD00E508A1 /* RNAdMobInterstitial.m */; };
 		A96DA7841C146DA600FC639B /* BannerView.m in Sources */ = {isa = PBXBuildFile; fileRef = A96DA7811C146DA600FC639B /* BannerView.m */; };
 		A96DA7851C146DA600FC639B /* RNAdMobManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A96DA7831C146DA600FC639B /* RNAdMobManager.m */; };
@@ -25,6 +27,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0CB8C0491D913E00002BC3EF /* RNDFPBannerView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNDFPBannerView.h; sourceTree = SOURCE_ROOT; };
+		0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNDFPBannerView.m; sourceTree = SOURCE_ROOT; };
+		0CB8C04C1D9143A6002BC3EF /* RNAdMobDFPManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobDFPManager.h; sourceTree = SOURCE_ROOT; };
+		0CB8C04D1D9143A6002BC3EF /* RNAdMobDFPManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAdMobDFPManager.m; sourceTree = SOURCE_ROOT; };
 		A962C2511CB27DBD00E508A1 /* RNAdMobInterstitial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobInterstitial.h; sourceTree = SOURCE_ROOT; };
 		A962C2521CB27DBD00E508A1 /* RNAdMobInterstitial.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = RNAdMobInterstitial.m; sourceTree = SOURCE_ROOT; };
 		A96DA7741C146D7200FC639B /* libRNAdMobManager.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNAdMobManager.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -64,12 +70,16 @@
 		A96DA7761C146D7200FC639B /* RNAdMobManager */ = {
 			isa = PBXGroup;
 			children = (
+				0CB8C04C1D9143A6002BC3EF /* RNAdMobDFPManager.h */,
+				0CB8C04D1D9143A6002BC3EF /* RNAdMobDFPManager.m */,
 				A96DA7801C146DA600FC639B /* BannerView.h */,
 				A96DA7811C146DA600FC639B /* BannerView.m */,
 				A96DA7821C146DA600FC639B /* RNAdMobManager.h */,
 				A96DA7831C146DA600FC639B /* RNAdMobManager.m */,
 				A962C2511CB27DBD00E508A1 /* RNAdMobInterstitial.h */,
 				A962C2521CB27DBD00E508A1 /* RNAdMobInterstitial.m */,
+				0CB8C0491D913E00002BC3EF /* RNDFPBannerView.h */,
+				0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */,
 			);
 			path = RNAdMobManager;
 			sourceTree = "<group>";
@@ -132,8 +142,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				A962C2531CB27DBD00E508A1 /* RNAdMobInterstitial.m in Sources */,
+				0CB8C04B1D913E00002BC3EF /* RNDFPBannerView.m in Sources */,
 				A96DA7841C146DA600FC639B /* BannerView.m in Sources */,
 				A96DA7851C146DA600FC639B /* RNAdMobManager.m in Sources */,
+				0CB8C04E1D9143A6002BC3EF /* RNAdMobDFPManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNDFPBannerView.h
+++ b/ios/RNDFPBannerView.h
@@ -1,0 +1,16 @@
+#import "RCTEventDispatcher.h"
+@import GoogleMobileAds;
+
+@class RCTEventDispatcher;
+
+@interface RNDFPBannerView : UIView <GADBannerViewDelegate>
+
+@property (nonatomic, copy) NSString *bannerSize;
+@property (nonatomic, copy) NSString *adUnitID;
+@property (nonatomic, copy) NSString *testDeviceID;
+
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
+- (GADAdSize)getAdSizeFromString:(NSString *)bannerSize;
+- (void)loadBanner;
+
+@end

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -1,0 +1,183 @@
+#import "RNDFPBannerView.h"
+#import "RCTBridgeModule.h"
+#import "UIView+React.h"
+#import "RCTLog.h"
+
+@implementation RNDFPBannerView {
+    DFPBannerView  *_bannerView;
+    RCTEventDispatcher *_eventDispatcher;
+}
+
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
+{
+    if ((self = [super initWithFrame:CGRectZero])) {
+        _eventDispatcher = eventDispatcher;
+    }
+    return self;
+}
+
+RCT_NOT_IMPLEMENTED(- (instancetype)initWithFrame:(CGRect)frame)
+RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:coder)
+
+- (void)insertReactSubview:(UIView *)view atIndex:(NSInteger)atIndex
+{
+    RCTLogError(@"AdMob Banner cannot have any subviews");
+    return;
+}
+
+- (void)removeReactSubview:(UIView *)subview
+{
+    RCTLogError(@"AdMob Banner cannot have any subviews");
+    return;
+}
+
+- (GADAdSize)getAdSizeFromString:(NSString *)bannerSize
+{
+    if ([bannerSize isEqualToString:@"banner"]) {
+        return kGADAdSizeBanner;
+    } else if ([bannerSize isEqualToString:@"largeBanner"]) {
+        return kGADAdSizeLargeBanner;
+    } else if ([bannerSize isEqualToString:@"mediumRectangle"]) {
+        return kGADAdSizeMediumRectangle;
+    } else if ([bannerSize isEqualToString:@"fullBanner"]) {
+        return kGADAdSizeFullBanner;
+    } else if ([bannerSize isEqualToString:@"leaderboard"]) {
+        return kGADAdSizeLeaderboard;
+    } else if ([bannerSize isEqualToString:@"smartBannerPortrait"]) {
+        return kGADAdSizeSmartBannerPortrait;
+    } else if ([bannerSize isEqualToString:@"smartBannerLandscape"]) {
+        return kGADAdSizeSmartBannerLandscape;
+    }
+    else {
+        return kGADAdSizeBanner;
+    }
+}
+
+-(void)loadBanner {
+    if (_adUnitID && _bannerSize) {
+        GADAdSize size = [self getAdSizeFromString:_bannerSize];
+        _bannerView = [[DFPBannerView alloc] initWithAdSize:size];
+        [_bannerView setAppEventDelegate:self]; //added Admob event dispatch listener
+        if(!CGRectEqualToRect(self.bounds, _bannerView.bounds)) {
+            [_eventDispatcher
+             sendInputEventWithName:@"onSizeChange"
+             body:@{
+                    @"target": self.reactTag,
+                    @"width": [NSNumber numberWithFloat: _bannerView.bounds.size.width],
+                    @"height": [NSNumber numberWithFloat: _bannerView.bounds.size.height]
+                    }];
+        }
+        _bannerView.delegate = self;
+        _bannerView.adUnitID = _adUnitID;
+        _bannerView.rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+        GADRequest *request = [GADRequest request];
+        if(_testDeviceID) {
+            if([_testDeviceID isEqualToString:@"EMULATOR"]) {
+                request.testDevices = @[kGADSimulatorID];
+            } else {
+                request.testDevices = @[_testDeviceID];
+            }
+        }
+        
+        [_bannerView loadRequest:request];
+    }
+}
+
+
+- (void)adView:(DFPBannerView *)banner
+didReceiveAppEvent:(NSString *)name
+      withInfo:(NSString *)info {
+    NSLog(@"Received app event (%@, %@)", name, info);
+    NSMutableDictionary *myDictionary = [[NSMutableDictionary alloc] init];
+    myDictionary[name] = info;
+    [_eventDispatcher sendInputEventWithName:@"onAdmobDispatchAppEvent" body:@{ @"target": self.reactTag, name: info }];
+}
+
+- (void)setBannerSize:(NSString *)bannerSize
+{
+    if(![bannerSize isEqual:_bannerSize]) {
+        _bannerSize = bannerSize;
+        if (_bannerView) {
+            [_bannerView removeFromSuperview];
+        }
+        [self loadBanner];
+    }
+}
+
+
+
+- (void)setAdUnitID:(NSString *)adUnitID
+{
+    if(![adUnitID isEqual:_adUnitID]) {
+        _adUnitID = adUnitID;
+        if (_bannerView) {
+            [_bannerView removeFromSuperview];
+        }
+        
+        [self loadBanner];
+    }
+}
+- (void)setTestDeviceID:(NSString *)testDeviceID
+{
+    if(![testDeviceID isEqual:_testDeviceID]) {
+        _testDeviceID = testDeviceID;
+        if (_bannerView) {
+            [_bannerView removeFromSuperview];
+        }
+        
+        [self loadBanner];
+    }
+}
+
+-(void)layoutSubviews
+{
+    [super layoutSubviews ];
+    
+    _bannerView.frame = CGRectMake(
+                                   self.bounds.origin.x,
+                                   self.bounds.origin.x,
+                                   _bannerView.frame.size.width,
+                                   _bannerView.frame.size.height);
+    [self addSubview:_bannerView];
+}
+
+- (void)removeFromSuperview
+{
+    _eventDispatcher = nil;
+    [super removeFromSuperview];
+}
+
+/// Tells the delegate an ad request loaded an ad.
+- (void)adViewDidReceiveAd:(DFPBannerView *)adView {
+    [_eventDispatcher sendInputEventWithName:@"onAdViewDidReceiveAd" body:@{ @"target": self.reactTag }];
+}
+
+/// Tells the delegate an ad request failed.
+- (void)adView:(DFPBannerView *)adView
+didFailToReceiveAdWithError:(GADRequestError *)error {
+    [_eventDispatcher sendInputEventWithName:@"onDidFailToReceiveAdWithError" body:@{ @"target": self.reactTag, @"error": [error localizedDescription] }];
+}
+
+/// Tells the delegate that a full screen view will be presented in response
+/// to the user clicking on an ad.
+- (void)adViewWillPresentScreen:(DFPBannerView *)adView {
+    [_eventDispatcher sendInputEventWithName:@"onAdViewWillPresentScreen" body:@{ @"target": self.reactTag }];
+}
+
+/// Tells the delegate that the full screen view will be dismissed.
+- (void)adViewWillDismissScreen:(DFPBannerView *)adView {
+    [_eventDispatcher sendInputEventWithName:@"onAdViewWillDismissScreen" body:@{ @"target": self.reactTag }];
+}
+
+/// Tells the delegate that the full screen view has been dismissed.
+- (void)adViewDidDismissScreen:(DFPBannerView *)adView {
+    [_eventDispatcher sendInputEventWithName:@"onAdViewDidDismissScreen" body:@{ @"target": self.reactTag }];
+}
+
+/// Tells the delegate that a user click will open another app (such as
+/// the App Store), backgrounding the current app.
+- (void)adViewWillLeaveApplication:(DFPBannerView *)adView {
+    [_eventDispatcher sendInputEventWithName:@"onAdViewWillLeaveApplication" body:@{ @"target": self.reactTag }];
+}
+
+@end


### PR DESCRIPTION
DFP sends app events to my app via the received advert, which can only be interpreted/caught by the DFPBanner/PublisherAdView. Normal AdView/GADBannerView does not have the app event listeners.
More info here: http://googleadsdeveloper.blogspot.co.za/2012/12/using-dfp-app-events-with-google-admob.html

Essentially duplicated AdMobBanner and added the needed events/props etc for the new Views. Please have a look and shout if I need to make changes.
Thanks for the module!