### PR TITLE
Migrating PropTypes

### DIFF
--- a/RNAdMobBanner.js
+++ b/RNAdMobBanner.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   NativeModules,
   requireNativeComponent,
   View,
   NativeEventEmitter,
+  ViewPropTypes,
 } from 'react-native';
 
 const RNBanner = requireNativeComponent('RNAdMob', AdMobBanner);
@@ -45,7 +47,7 @@ export default class AdMobBanner extends React.Component {
 }
 
 AdMobBanner.propTypes = {
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
 
   /**
    * AdMob iOS library banner size constants
@@ -60,28 +62,28 @@ AdMobBanner.propTypes = {
    *
    * banner is default
    */
-  bannerSize: React.PropTypes.string,
+  bannerSize: PropTypes.string,
 
   /**
    * AdMob ad unit ID
    */
-  adUnitID: React.PropTypes.string,
+  adUnitID: PropTypes.string,
 
   /**
    * Test device ID
    */
-  testDeviceID: React.PropTypes.string,
+  testDeviceID: PropTypes.string,
 
   /**
    * AdMob iOS library events
    */
-  adViewDidReceiveAd: React.PropTypes.func,
-  didFailToReceiveAdWithError: React.PropTypes.func,
-  adViewWillPresentScreen: React.PropTypes.func,
-  adViewWillDismissScreen: React.PropTypes.func,
-  adViewDidDismissScreen: React.PropTypes.func,
-  adViewWillLeaveApplication: React.PropTypes.func,
-  ...View.propTypes,
+  adViewDidReceiveAd: PropTypes.func,
+  didFailToReceiveAdWithError: PropTypes.func,
+  adViewWillPresentScreen: PropTypes.func,
+  adViewWillDismissScreen: PropTypes.func,
+  adViewDidDismissScreen: PropTypes.func,
+  adViewWillLeaveApplication: PropTypes.func,
+  ...ViewPropTypes,
 };
 
 AdMobBanner.defaultProps = { bannerSize: 'smartBannerPortrait', didFailToReceiveAdWithError: () => {} };

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   NativeModules,
   requireNativeComponent,
   View,
   NativeEventEmitter,
+  ViewPropTypes,
 } from 'react-native';
 
 const RNBanner = requireNativeComponent('RNAdMobDFP', PublisherBanner);
@@ -46,7 +48,7 @@ export default class PublisherBanner extends React.Component {
 }
 
 PublisherBanner.propTypes = {
-  style: View.propTypes.style,
+  style: ViewPropTypes.style,
 
   /**
    * AdMob iOS library banner size constants
@@ -61,29 +63,29 @@ PublisherBanner.propTypes = {
    *
    * banner is default
    */
-  bannerSize: React.PropTypes.string,
+  bannerSize: PropTypes.string,
 
   /**
    * AdMob ad unit ID
    */
-  adUnitID: React.PropTypes.string,
+  adUnitID: PropTypes.string,
 
   /**
    * Test device ID
    */
-  testDeviceID: React.PropTypes.string,
+  testDeviceID: PropTypes.string,
 
   /**
    * AdMob iOS library events
    */
-  adViewDidReceiveAd: React.PropTypes.func,
-  didFailToReceiveAdWithError: React.PropTypes.func,
-  adViewWillPresentScreen: React.PropTypes.func,
-  adViewWillDismissScreen: React.PropTypes.func,
-  adViewDidDismissScreen: React.PropTypes.func,
-  adViewWillLeaveApplication: React.PropTypes.func,
-  admobDispatchAppEvent: React.PropTypes.func,
-  ...View.propTypes,
+  adViewDidReceiveAd: PropTypes.func,
+  didFailToReceiveAdWithError: PropTypes.func,
+  adViewWillPresentScreen: PropTypes.func,
+  adViewWillDismissScreen: PropTypes.func,
+  adViewDidDismissScreen: PropTypes.func,
+  adViewWillLeaveApplication: PropTypes.func,
+  admobDispatchAppEvent: PropTypes.func,
+  ...ViewPropTypes,
 };
 
 PublisherBanner.defaultProps = { bannerSize: 'smartBannerPortrait', didFailToReceiveAdWithError: () => {} ,

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   "repository": {
     "type": "git",
     "url": "git@github.com:sbugert/react-native-admob.git"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
`react-native-admob` is raising a warning at test time, due to deprecated fashion of prop type checking.
![image](https://user-images.githubusercontent.com/823150/27734279-829cfee4-5d70-11e7-8f7b-a4e03873b2c4.png)

I'm corcerned about backwards compatibility with `ViewPropTypes` since this is not available on react-native versions earlier than 0.44.0.

For reference:
https://github.com/facebook/react-native/commit/9a88c721635ddb1ad6624b7dd3fc9e21530b00e2
https://github.com/testshallpass/react-native-dropdownalert/issues/64