### PR TITLE
Native Express Ad iOS

### DIFF
--- a/RNAdMobNativeExpress.js
+++ b/RNAdMobNativeExpress.js
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import { Platform, requireNativeComponent, View } from 'react-native';
+import _isEqual from 'lodash/isEqual';
+
+const RNBanner = requireNativeComponent('RNAdMobNativeExpress', AdMobNativeExpress);
+
+
+export default class AdMobNativeExpress extends Component {
+  constructor() {
+    super();
+    this.onSizeChange = this.onSizeChange.bind(this);
+    this.state = {
+      style: {}
+    };
+  }
+
+  onSizeChange(event) {
+    const { height, width } = event.nativeEvent;
+    this.setState({ style: { width, height } });
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    return !_isEqual(this.props, nextProps) || !_isEqual(this.state, nextState)
+  }
+
+  render() {
+    // if (Platform.OS === 'ios') return null
+
+    const { adUnitID, testDeviceID, bannerWidth, bannerHeight, didFailToReceiveAdWithError } = this.props;
+    return (
+      <View style={this.props.style}>
+        <RNBanner
+          style={this.state.style}
+          onSizeChange={this.onSizeChange.bind(this)}
+          onAdViewDidReceiveAd={this.props.adViewDidReceiveAd}
+          onDidFailToReceiveAdWithError={(event) => didFailToReceiveAdWithError(event.nativeEvent.error)}
+          onAdViewWillPresentScreen={this.props.adViewWillPresentScreen}
+          onAdViewWillDismissScreen={this.props.adViewWillDismissScreen}
+          onAdViewDidDismissScreen={this.props.adViewDidDismissScreen}
+          onAdViewWillLeaveApplication={this.props.adViewWillLeaveApplication}
+          bannerWidth={parseInt(bannerWidth)}
+          bannerHeight={parseInt(bannerHeight)}
+          testDeviceID={testDeviceID}
+          adUnitID={adUnitID}
+          />
+      </View>
+    );
+  }
+}
+
+AdMobNativeExpress.propTypes = {
+  style: View.propTypes.style,
+
+  /**
+   * Native Express size
+   * (https://firebase.google.com/docs/admob/android/native-express#choose_a_size)
+   */
+  bannerWidth: React.PropTypes.number,
+  bannerHeight: React.PropTypes.number,
+
+  /**
+   * AdMob ad unit ID
+   */
+  adUnitID: React.PropTypes.string,
+
+  /**
+   * Test device ID
+   */
+  testDeviceID: React.PropTypes.string,
+
+  /**
+   * AdMob library events
+   */
+  adViewDidReceiveAd: React.PropTypes.func,
+  didFailToReceiveAdWithError: React.PropTypes.func,
+  adViewWillPresentScreen: React.PropTypes.func,
+  adViewWillDismissScreen: React.PropTypes.func,
+  adViewDidDismissScreen: React.PropTypes.func,
+  adViewWillLeaveApplication: React.PropTypes.func,
+  ...View.propTypes,
+};
+
+AdMobNativeExpress.defaultProps = {
+  bannerWidth: 400,
+  bannerHeight: 300,
+  didFailToReceiveAdWithError: () => {}
+};

--- a/RNAdMobNativeExpress.js
+++ b/RNAdMobNativeExpress.js
@@ -15,6 +15,7 @@ export default class AdMobNativeExpress extends Component {
   }
 
   onSizeChange(event) {
+    console.log(event);
     const { height, width } = event.nativeEvent;
     this.setState({ style: { width, height } });
   }

--- a/ios/RNAdMobInterstitial.h
+++ b/ios/RNAdMobInterstitial.h
@@ -2,7 +2,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventDispatcher.h>
 #else
-#import "RCTBridgeModule.h"
+// #import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 #import "RCTEventDispatcher.h"
 #endif
 

--- a/ios/RNAdMobManager.xcodeproj/project.pbxproj
+++ b/ios/RNAdMobManager.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		0CB8C04B1D913E00002BC3EF /* RNDFPBannerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */; };
 		0CB8C04E1D9143A6002BC3EF /* RNAdMobDFPManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8C04D1D9143A6002BC3EF /* RNAdMobDFPManager.m */; };
+		773320471F09AB6B00C57B62 /* RNAdMobNativeExpressManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 773320441F09AB6B00C57B62 /* RNAdMobNativeExpressManager.m */; };
+		773320481F09AB6B00C57B62 /* RNAdMobNativeExpressView.m in Sources */ = {isa = PBXBuildFile; fileRef = 773320461F09AB6B00C57B62 /* RNAdMobNativeExpressView.m */; };
 		A90F2F8C1D50AEF200F2A2E3 /* RNAdMobRewarded.m in Sources */ = {isa = PBXBuildFile; fileRef = A90F2F8B1D50AEF200F2A2E3 /* RNAdMobRewarded.m */; };
 		A962C2531CB27DBD00E508A1 /* RNAdMobInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = A962C2521CB27DBD00E508A1 /* RNAdMobInterstitial.m */; };
 		A96DA7841C146DA600FC639B /* BannerView.m in Sources */ = {isa = PBXBuildFile; fileRef = A96DA7811C146DA600FC639B /* BannerView.m */; };
@@ -32,6 +34,10 @@
 		0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNDFPBannerView.m; sourceTree = SOURCE_ROOT; };
 		0CB8C04C1D9143A6002BC3EF /* RNAdMobDFPManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobDFPManager.h; sourceTree = SOURCE_ROOT; };
 		0CB8C04D1D9143A6002BC3EF /* RNAdMobDFPManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAdMobDFPManager.m; sourceTree = SOURCE_ROOT; };
+		773320431F09AB6B00C57B62 /* RNAdMobNativeExpressManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobNativeExpressManager.h; sourceTree = SOURCE_ROOT; };
+		773320441F09AB6B00C57B62 /* RNAdMobNativeExpressManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAdMobNativeExpressManager.m; sourceTree = SOURCE_ROOT; };
+		773320451F09AB6B00C57B62 /* RNAdMobNativeExpressView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobNativeExpressView.h; sourceTree = SOURCE_ROOT; };
+		773320461F09AB6B00C57B62 /* RNAdMobNativeExpressView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAdMobNativeExpressView.m; sourceTree = SOURCE_ROOT; };
 		A90F2F8A1D50AEF200F2A2E3 /* RNAdMobRewarded.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobRewarded.h; sourceTree = SOURCE_ROOT; };
 		A90F2F8B1D50AEF200F2A2E3 /* RNAdMobRewarded.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAdMobRewarded.m; sourceTree = SOURCE_ROOT; };
 		A962C2511CB27DBD00E508A1 /* RNAdMobInterstitial.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobInterstitial.h; sourceTree = SOURCE_ROOT; };
@@ -73,6 +79,10 @@
 		A96DA7761C146D7200FC639B /* RNAdMobManager */ = {
 			isa = PBXGroup;
 			children = (
+				773320431F09AB6B00C57B62 /* RNAdMobNativeExpressManager.h */,
+				773320441F09AB6B00C57B62 /* RNAdMobNativeExpressManager.m */,
+				773320451F09AB6B00C57B62 /* RNAdMobNativeExpressView.h */,
+				773320461F09AB6B00C57B62 /* RNAdMobNativeExpressView.m */,
 				0CB8C04C1D9143A6002BC3EF /* RNAdMobDFPManager.h */,
 				0CB8C04D1D9143A6002BC3EF /* RNAdMobDFPManager.m */,
 				A96DA7801C146DA600FC639B /* BannerView.h */,
@@ -150,6 +160,8 @@
 				0CB8C04B1D913E00002BC3EF /* RNDFPBannerView.m in Sources */,
 				A90F2F8C1D50AEF200F2A2E3 /* RNAdMobRewarded.m in Sources */,
 				A96DA7841C146DA600FC639B /* BannerView.m in Sources */,
+				773320481F09AB6B00C57B62 /* RNAdMobNativeExpressView.m in Sources */,
+				773320471F09AB6B00C57B62 /* RNAdMobNativeExpressManager.m in Sources */,
 				A96DA7851C146DA600FC639B /* RNAdMobManager.m in Sources */,
 				0CB8C04E1D9143A6002BC3EF /* RNAdMobDFPManager.m in Sources */,
 			);

--- a/ios/RNAdMobNativeExpressManager.h
+++ b/ios/RNAdMobNativeExpressManager.h
@@ -1,0 +1,9 @@
+#if __has_include(<React/RCTViewManager.h>)
+#import <React/RCTViewManager.h>
+#else
+#import "RCTViewManager.h"
+#endif
+
+@interface RNAdMobNativeExpressManager : RCTViewManager
+
+@end

--- a/ios/RNAdMobNativeExpressManager.m
+++ b/ios/RNAdMobNativeExpressManager.m
@@ -1,0 +1,40 @@
+#import "RNAdMobNativeExpressManager.h"
+#import "RNAdMobNativeExpressView.h"
+
+#if __has_include(<React/RCTBridge.h>)
+#import <React/RCTBridge.h>
+#else
+#import "RCTBridge.h"
+#endif
+
+@implementation RNAdMobNativeExpressManager
+
+RCT_EXPORT_MODULE();
+
+@synthesize bridge = _bridge;
+
+- (UIView *)view
+{
+  return [[RNAdMobNativeExpressView alloc] init];
+}
+
+- (dispatch_queue_t)methodQueue
+{
+  return dispatch_get_main_queue();
+}
+
+RCT_EXPORT_VIEW_PROPERTY(bannerHeight, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(bannerWidth, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(adUnitID, NSString);
+RCT_EXPORT_VIEW_PROPERTY(testDeviceID, NSString);
+
+RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdmobDispatchAppEvent, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdViewDidReceiveAd, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onDidFailToReceiveAdWithError, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdViewWillPresentScreen, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdViewWillDismissScreen, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdViewDidDismissScreen, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdViewWillLeaveApplication, RCTBubblingEventBlock)
+
+@end

--- a/ios/RNAdMobNativeExpressView.h
+++ b/ios/RNAdMobNativeExpressView.h
@@ -10,8 +10,8 @@
 
 @interface RNAdMobNativeExpressView : UIView <GADNativeExpressAdViewDelegate>
 
-@property (nonatomic, copy) NSString *bannerWidth;
-@property (nonatomic, copy) NSString *bannerHeight;
+@property (nonatomic, copy) NSNumber *bannerWidth;
+@property (nonatomic, copy) NSNumber *bannerHeight;
 @property (nonatomic, copy) NSString *adUnitID;
 @property (nonatomic, copy) NSString *testDeviceID;
 

--- a/ios/RNAdMobNativeExpressView.h
+++ b/ios/RNAdMobNativeExpressView.h
@@ -1,0 +1,28 @@
+#if __has_include(<React/RCTEventDispatcher.h>)
+#import <React/RCTComponent.h>
+#else
+#import "RCTComponent.h"
+#endif
+
+@import GoogleMobileAds;
+
+@class RCTEventDispatcher;
+
+@interface RNAdMobNativeExpressView : UIView <GADNativeExpressAdViewDelegate>
+
+@property (nonatomic, copy) NSString *bannerWidth;
+@property (nonatomic, copy) NSString *bannerHeight;
+@property (nonatomic, copy) NSString *adUnitID;
+@property (nonatomic, copy) NSString *testDeviceID;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdViewDidReceiveAd;
+@property (nonatomic, copy) RCTBubblingEventBlock onDidFailToReceiveAdWithError;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdViewWillPresentScreen;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdViewWillDismissScreen;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdViewDidDismissScreen;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdViewWillLeaveApplication;
+
+- (void)loadBanner;
+
+@end

--- a/ios/RNAdMobNativeExpressView.m
+++ b/ios/RNAdMobNativeExpressView.m
@@ -56,10 +56,7 @@
     _bannerView = [[GADNativeExpressAdView alloc] initWithAdSize:size];
     if(!CGRectEqualToRect(self.bounds, _bannerView.bounds)) {
       if (self.onSizeChange) {
-        self.onSizeChange(@{
-               @"width": [NSNumber numberWithFloat: _bannerView.bounds.size.width],
-               @"height": [NSNumber numberWithFloat: _bannerView.bounds.size.height]
-        });
+        [self callOnSizeChange];
       }
     }
     _bannerView.delegate = self;
@@ -76,17 +73,6 @@
     [_bannerView loadRequest:request];
   }
 }
-
-// - (void)setBannerSize:(NSString *)bannerSize
-// {
-//   if(![bannerSize isEqual:_bannerSize]) {
-//     _bannerSize = bannerSize;
-//     if (_bannerView) {
-//       [_bannerView removeFromSuperview];
-//     }
-//     [self loadBanner];
-//   }
-// }
 
 - (void)setBannerWidth:(NSString *)bannerWidth
 {
@@ -141,6 +127,24 @@
     _bannerView.frame.size.width,
     _bannerView.frame.size.height);
   [self addSubview:_bannerView];
+}
+
+-(void)callOnSizeChange {
+  if (self.onSizeChange) {
+    self.onSizeChange(@{
+      @"width": [NSNumber numberWithFloat: _bannerView.bounds.size.width],
+      @"height": [NSNumber numberWithFloat: _bannerView.bounds.size.height]
+    });
+  }
+}
+
+
+- (void)setOnSizeChange:(RCTBubblingEventBlock)onSizeChange
+{
+  _onSizeChange = onSizeChange;
+  if (_bannerView) {
+    [self callOnSizeChange];
+  }
 }
 
 /// Tells the delegate an ad request loaded an ad.

--- a/ios/RNAdMobNativeExpressView.m
+++ b/ios/RNAdMobNativeExpressView.m
@@ -1,0 +1,191 @@
+#import "RNAdMobNativeExpressView.h"
+
+#if __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#import <React/UIView+React.h>
+#import <React/RCTLog.h>
+#else
+#import "RCTBridgeModule.h"
+#import "UIView+React.h"
+#import "RCTLog.h"
+#endif
+
+@implementation RNAdMobNativeExpressView {
+  GADNativeExpressAdView  *_bannerView;
+}
+
+- (void)insertReactSubview:(UIView *)view atIndex:(NSInteger)atIndex
+{
+  RCTLogError(@"AdMob Banner cannot have any subviews");
+  return;
+}
+
+- (void)removeReactSubview:(UIView *)subview
+{
+  RCTLogError(@"AdMob Banner cannot have any subviews");
+  return;
+}
+
+// - (GADAdSize)getAdSizeFromString:(NSString *)bannerSize
+// {
+//   if ([bannerSize isEqualToString:@"banner"]) {
+//     return kGADAdSizeBanner;
+//   } else if ([bannerSize isEqualToString:@"largeBanner"]) {
+//     return kGADAdSizeLargeBanner;
+//   } else if ([bannerSize isEqualToString:@"mediumRectangle"]) {
+//     return kGADAdSizeMediumRectangle;
+//   } else if ([bannerSize isEqualToString:@"fullBanner"]) {
+//     return kGADAdSizeFullBanner;
+//   } else if ([bannerSize isEqualToString:@"leaderboard"]) {
+//     return kGADAdSizeLeaderboard;
+//   } else if ([bannerSize isEqualToString:@"smartBannerPortrait"]) {
+//     return kGADAdSizeSmartBannerPortrait;
+//   } else if ([bannerSize isEqualToString:@"smartBannerLandscape"]) {
+//     return kGADAdSizeSmartBannerLandscape;
+//   } else {
+//     return kGADAdSizeBanner;
+//   }
+// }
+
+-(void)loadBanner 
+{
+  if (_adUnitID && _bannerWidth && _bannerHeight) {
+    NSInteger intWidth = [_bannerWidth intValue];
+    NSInteger intHeight = [_bannerHeight intValue];
+    GADAdSize size = GADAdSizeFromCGSize(CGSizeMake(intWidth, intHeight));
+    _bannerView = [[GADNativeExpressAdView alloc] initWithAdSize:size];
+    if(!CGRectEqualToRect(self.bounds, _bannerView.bounds)) {
+      if (self.onSizeChange) {
+        self.onSizeChange(@{
+               @"width": [NSNumber numberWithFloat: _bannerView.bounds.size.width],
+               @"height": [NSNumber numberWithFloat: _bannerView.bounds.size.height]
+        });
+      }
+    }
+    _bannerView.delegate = self;
+    _bannerView.adUnitID = _adUnitID;
+    _bannerView.rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
+    GADRequest *request = [GADRequest request];
+    if(_testDeviceID) {
+      if([_testDeviceID isEqualToString:@"EMULATOR"]) {
+        request.testDevices = @[kGADSimulatorID];
+      } else {
+        request.testDevices = @[_testDeviceID];
+      }
+    }
+    [_bannerView loadRequest:request];
+  }
+}
+
+// - (void)setBannerSize:(NSString *)bannerSize
+// {
+//   if(![bannerSize isEqual:_bannerSize]) {
+//     _bannerSize = bannerSize;
+//     if (_bannerView) {
+//       [_bannerView removeFromSuperview];
+//     }
+//     [self loadBanner];
+//   }
+// }
+
+- (void)setBannerWidth:(NSString *)bannerWidth
+{
+  if(![bannerWidth isEqual:_bannerWidth]) {
+    _bannerWidth = bannerWidth;
+    if (_bannerView) {
+      [_bannerView removeFromSuperview];
+    }
+    [self loadBanner];
+  }
+}
+
+- (void)setBannerHeight:(NSString *)bannerHeight
+{
+  if(![bannerHeight isEqual:_bannerHeight]) {
+    _bannerHeight = bannerHeight;
+    if (_bannerView) {
+      [_bannerView removeFromSuperview];
+    }
+    [self loadBanner];
+  }
+}
+
+- (void)setAdUnitID:(NSString *)adUnitID
+{
+  if(![adUnitID isEqual:_adUnitID]) {
+    _adUnitID = adUnitID;
+    if (_bannerView) {
+      [_bannerView removeFromSuperview];
+    }
+    [self loadBanner];
+  }
+}
+
+- (void)setTestDeviceID:(NSString *)testDeviceID
+{
+  if(![testDeviceID isEqual:_testDeviceID]) {
+    _testDeviceID = testDeviceID;
+    if (_bannerView) {
+      [_bannerView removeFromSuperview];
+    }
+    [self loadBanner];
+  }
+}
+
+-(void)layoutSubviews
+{
+  [super layoutSubviews];  
+  self.frame = CGRectMake(
+    self.bounds.origin.x,
+    self.bounds.origin.x,
+    _bannerView.frame.size.width,
+    _bannerView.frame.size.height);
+  [self addSubview:_bannerView];
+}
+
+/// Tells the delegate an ad request loaded an ad.
+- (void)adViewDidReceiveAd:(GADNativeExpressAdView *)adView {
+  if (self.onAdViewDidReceiveAd) {
+    self.onAdViewDidReceiveAd(@{});
+  }
+}
+
+/// Tells the delegate an ad request failed.
+- (void)adView:(GADNativeExpressAdView *)adView
+didFailToReceiveAdWithError:(GADRequestError *)error {
+  if (self.onDidFailToReceiveAdWithError) {
+    self.onDidFailToReceiveAdWithError(@{@"error": [error localizedDescription]});
+  }
+}
+
+/// Tells the delegate that a full screen view will be presented in response
+/// to the user clicking on an ad.
+- (void)adViewWillPresentScreen:(GADNativeExpressAdView *)adView {
+  if (self.onAdViewWillPresentScreen) {
+    self.onAdViewWillPresentScreen(@{});
+  }
+}
+
+/// Tells the delegate that the full screen view will be dismissed.
+- (void)adViewWillDismissScreen:(GADNativeExpressAdView *)adView {
+  if (self.onAdViewWillDismissScreen) {
+    self.onAdViewWillDismissScreen(@{});
+  }
+}
+
+/// Tells the delegate that the full screen view has been dismissed.
+- (void)adViewDidDismissScreen:(GADNativeExpressAdView *)adView {
+  if (self.onAdViewDidDismissScreen) {
+    self.onAdViewDidDismissScreen(@{});
+  }
+}
+
+/// Tells the delegate that a user click will open another app (such as
+/// the App Store), backgrounding the current app.
+- (void)adViewWillLeaveApplication:(GADNativeExpressAdView *)adView {
+  if (self.onAdViewWillLeaveApplication) {
+    self.onAdViewWillLeaveApplication(@{});
+  }
+}
+
+@end


### PR DESCRIPTION
These changes should be compatible with the android implementation contained in PR #127. 

For some reason, `onSizeChange` was not firing because `if (self.onSizeChange)` in `RNAdMobNativeExpressView.m` was returning false. I reverted to an older implementation that uses `setOnSizeChange` which seems to work. I don't have a ton of iOS experience, so I apologize I was not able to make this work in a way that uses the same syntax as the other component types.

