### PR TITLE
Add custom targeting prop on iOS

### DIFF
--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -24,7 +24,8 @@ export default class PublisherBanner extends React.Component {
   }
 
   render() {
-    const { adUnitID, testDeviceID, bannerSize, style, didFailToReceiveAdWithError,admobDispatchAppEvent } = this.props;
+    const { adUnitID, testDeviceID, bannerSize, style, didFailToReceiveAdWithError,admobDispatchAppEvent, customTargeting } = this.props;
+
     return (
       <View style={this.props.style}>
         <RNBanner
@@ -39,6 +40,7 @@ export default class PublisherBanner extends React.Component {
           onAdmobDispatchAppEvent={(event) => admobDispatchAppEvent(event)}
           testDeviceID={testDeviceID}
           adUnitID={adUnitID}
+          customTargeting={customTargeting}
           bannerSize={bannerSize} />
       </View>
     );
@@ -73,6 +75,10 @@ PublisherBanner.propTypes = {
    */
   testDeviceID: React.PropTypes.string,
 
+  /**
+   * Custom targeting for DFP Banners
+   */
+  customTargeting: React.PropTypes.object,
   /**
    * AdMob iOS library events
    */

--- a/ios/RNAdMobDFPManager.m
+++ b/ios/RNAdMobDFPManager.m
@@ -27,6 +27,7 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_VIEW_PROPERTY(bannerSize, NSString);
 RCT_EXPORT_VIEW_PROPERTY(adUnitID, NSString);
 RCT_EXPORT_VIEW_PROPERTY(testDeviceID, NSString);
+RCT_EXPORT_VIEW_PROPERTY(customTargeting, NSDictionary);
 
 RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdmobDispatchAppEvent, RCTBubblingEventBlock)

--- a/ios/RNDFPBannerView.h
+++ b/ios/RNDFPBannerView.h
@@ -13,6 +13,7 @@
 @property (nonatomic, copy) NSString *bannerSize;
 @property (nonatomic, copy) NSString *adUnitID;
 @property (nonatomic, copy) NSString *testDeviceID;
+@property (nonatomic, copy) NSDictionary *customTargeting;
 
 @property (nonatomic, copy) RCTBubblingEventBlock onSizeChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onAdmobDispatchAppEvent;

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -64,7 +64,12 @@
         _bannerView.delegate = self;
         _bannerView.adUnitID = _adUnitID;
         _bannerView.rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-        GADRequest *request = [GADRequest request];
+        DFPRequest *request = [DFPRequest request];
+
+        if (_customTargeting) {
+            request.customTargeting = _customTargeting;
+        }
+
         if(_testDeviceID) {
             if([_testDeviceID isEqualToString:@"EMULATOR"]) {
                 request.testDevices = @[kGADSimulatorID];
@@ -115,6 +120,17 @@ didReceiveAppEvent:(NSString *)name
 {
     if(![testDeviceID isEqual:_testDeviceID]) {
         _testDeviceID = testDeviceID;
+        if (_bannerView) {
+            [_bannerView removeFromSuperview];
+        }
+        [self loadBanner];
+    }
+}
+
+- (void)setCustomTargeting:(NSDictionary *)customTargeting
+{
+    if(![customTargeting isEqual:_customTargeting]) {
+        _customTargeting = customTargeting;
         if (_bannerView) {
             [_bannerView removeFromSuperview];
         }


### PR DESCRIPTION
Hello,

This module has been very helpful for us, thanks a lot!

This adds a [custom targeting](https://developers.google.com/mobile-ads-sdk/docs/dfp/ios/targeting#custom_targeting) prop for iOS.