### PR TITLE
add namespace to events

### DIFF
--- a/RNAdMobInterstitial.js
+++ b/RNAdMobInterstitial.js
@@ -7,35 +7,53 @@ import { createErrorFromErrorData } from './utils';
 
 const RNAdMobInterstitial = NativeModules.RNAdMobInterstitial;
 
-const adMobInterstitialEmitter = new NativeEventEmitter(RNAdMobInterstitial);
+const eventEmitter = new NativeEventEmitter(RNAdMobInterstitial);
 
-const eventHandlers = {};
+const eventMap = {
+  adLoaded: 'interstitialAdLoaded',
+  adFailedToLoad: 'interstitialAdFailedToLoad',
+  adOpened: 'interstitialAdOpened',
+  adClosed: 'interstitialAdClosed',
+  adLeftApplication: 'interstitialAdLeftApplication',
+};
 
-const addEventListener = (type, handler) => {
-  eventHandlers[type] = eventHandlers[type] || new Map();
-  if (type === 'adFailedToLoad') {
-    eventHandlers[type].set(handler, adMobInterstitialEmitter.addListener(type, error => handler(createErrorFromErrorData(error))));
+const _subscriptions = new Map();
+
+const addEventListener = (event, handler) => {
+  const mappedEvent = eventMap[event];
+  if (mappedEvent) {
+    let listener;
+    if (event === 'adFailedToLoad') {
+      listener = eventEmitter.addListener(mappedEvent, error => handler(createErrorFromErrorData(error)));
+    } else {
+      listener = eventEmitter.addListener(mappedEvent, handler);
+    }
+    _subscriptions.set(handler, listener);
+    return {
+      remove: () => removeEventListener(event, handler)
+    };
   } else {
-    eventHandlers[type].set(handler, adMobInterstitialEmitter.addListener(type, handler));
+    console.warn(`Trying to subscribe to unknown event: "${event}"`);
+    return {
+      remove: () => {},
+    };
   }
 };
 
 const removeEventListener = (type, handler) => {
-  if (!eventHandlers[type].has(handler)) {
+  const listener = _subscriptions.get(handler);
+  if (!listener) {
     return;
   }
-  eventHandlers[type].get(handler).remove();
-  eventHandlers[type].delete(handler);
+  listener.remove();
+  _subscriptions.delete(handler);
 };
 
 const removeAllListeners = () => {
-  const types = Object.keys(eventHandlers);
-  types.forEach(type => (
-    eventHandlers[type].forEach((subscription, key, map) => {
-      subscription.remove();
-      map.delete(key);
-    })
-  ));
+  _subscriptions.forEach((listener, key, map) => {
+    listener.remove();
+    map.delete(key);
+  });
 };
 
 export default {

--- a/RNAdMobRewarded.js
+++ b/RNAdMobRewarded.js
@@ -7,35 +7,55 @@ import { createErrorFromErrorData } from './utils';
 
 const RNAdMobRewarded = NativeModules.RNAdMobRewarded;
 
-const adMobRewardedEmitter = new NativeEventEmitter(RNAdMobRewarded);
+const eventEmitter = new NativeEventEmitter(RNAdMobRewarded);
 
-const eventHandlers = {};
+const eventMap = {
+  adLoaded: 'rewardedVideoAdLoaded',
+  adFailedToLoad: 'rewardedVideoAdFailedToLoad',
+  adOpened: 'rewardedVideoAdOpened',
+  adClosed: 'rewardedVideoAdClosed',
+  adLeftApplication: 'rewardedVideoAdLeftApplication',
+  rewarded: 'rewardedVideoAdRewarded',
+  videoStarted: 'rewardedVideoAdVideoStarted',
+};
 
-const addEventListener = (type, handler) => {
-  eventHandlers[type] = eventHandlers[type] || new Map();
-  if (type === 'adFailedToLoad') {
-    eventHandlers[type].set(handler, adMobRewardedEmitter.addListener(type, error => handler(createErrorFromErrorData(error))));
+const _subscriptions = new Map();
+
+const addEventListener = (event, handler) => {
+  const mappedEvent = eventMap[event];
+  if (mappedEvent) {
+    let listener;
+    if (event === 'adFailedToLoad') {
+      listener = eventEmitter.addListener(mappedEvent, error => handler(createErrorFromErrorData(error)));
+    } else {
+      listener = eventEmitter.addListener(mappedEvent, handler);
+    }
+    _subscriptions.set(handler, listener);
+    return {
+      remove: () => removeEventListener(event, handler)
+    };
   } else {
-    eventHandlers[type].set(handler, adMobRewardedEmitter.addListener(type, handler));
+    console.warn(`Trying to subscribe to unknown event: "${event}"`);
+    return {
+      remove: () => {},
+    };
   }
 };
 
 const removeEventListener = (type, handler) => {
-  if (!eventHandlers[type].has(handler)) {
+  const listener = _subscriptions.get(handler);
+  if (!listener) {
     return;
   }
-  eventHandlers[type].get(handler).remove();
-  eventHandlers[type].delete(handler);
+  listener.remove();
+  _subscriptions.delete(handler);
 };
 
 const removeAllListeners = () => {
-  const types = Object.keys(eventHandlers);
-  types.forEach(type => (
-    eventHandlers[type].forEach((subscription, key, map) => {
-      subscription.remove();
-      map.delete(key);
-    })
-  ));
+  _subscriptions.forEach((listener, key, map) => {
+    listener.remove();
+    map.delete(key);
+  });
 };
 
 export default {

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
@@ -27,11 +27,11 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
 
     public static final String REACT_CLASS = "RNAdMobInterstitial";
 
-    public static final String EVENT_AD_LOADED = "onAdLoaded";
-    public static final String EVENT_AD_FAILED_TO_LOAD = "onAdFailedToLoad";
-    public static final String EVENT_AD_OPENED = "onAdOpened";
-    public static final String EVENT_AD_CLOSED = "onAdClosed";
-    public static final String EVENT_AD_LEFT_APPLICATION = "onAdLeftApplication";
+    public static final String EVENT_AD_LOADED = "interstitialAdLoaded";
+    public static final String EVENT_AD_FAILED_TO_LOAD = "interstitialAdFailedToLoad";
+    public static final String EVENT_AD_OPENED = "interstitialAdOpened";
+    public static final String EVENT_AD_CLOSED = "interstitialAdClosed";
+    public static final String EVENT_AD_LEFT_APPLICATION = "interstitialAdLeftApplication";
 
     InterstitialAd mInterstitialAd;
     String[] testDevices;

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -26,13 +26,13 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
 
     public static final String REACT_CLASS = "RNAdMobRewarded";
 
-    public static final String EVENT_AD_LOADED = "onAdLoaded";
-    public static final String EVENT_AD_FAILED_TO_LOAD = "onAdFailedToLoad";
-    public static final String EVENT_AD_OPENED = "onAdOpened";
-    public static final String EVENT_AD_CLOSED = "onAdClosed";
-    public static final String EVENT_AD_LEFT_APPLICATION = "onAdLeftApplication";
-    public static final String EVENT_REWARDED = "rewarded";
-    public static final String EVENT_VIDEO_STARTED = "videoStarted";
+    public static final String EVENT_AD_LOADED = "rewardedVideoAdLoaded";
+    public static final String EVENT_AD_FAILED_TO_LOAD = "rewardedVideoAdFailedToLoad";
+    public static final String EVENT_AD_OPENED = "rewardedVideoAdOpened";
+    public static final String EVENT_AD_CLOSED = "rewardedVideoAdClosed";
+    public static final String EVENT_AD_LEFT_APPLICATION = "rewardedVideoAdLeftApplication";
+    public static final String EVENT_REWARDED = "rewardedVideoAdRewarded";
+    public static final String EVENT_VIDEO_STARTED = "rewardedVideoAdVideoStarted";
 
     RewardedVideoAd mRewardedVideoAd;
     String adUnitID;

--- a/ios/RNAdMobInterstitial.m
+++ b/ios/RNAdMobInterstitial.m
@@ -6,12 +6,12 @@
 #import "RCTUtils.h"
 #endif
 
-static NSString *const kEventAdLoaded = @"adLoaded";
-static NSString *const kEventAdFailedToLoad = @"adFailedToLoad";
-static NSString *const kEventAdOpened = @"adOpened";
-static NSString *const kEventAdFailedToOpen = @"adFailedToOpen";
-static NSString *const kEventAdClosed = @"adClosed";
-static NSString *const kEventAdLeftApplication = @"adLeftApplication";
+static NSString *const kEventAdLoaded = @"interstitialAdLoaded";
+static NSString *const kEventAdFailedToLoad = @"interstitialAdFailedToLoad";
+static NSString *const kEventAdOpened = @"interstitialAdOpened";
+static NSString *const kEventAdFailedToOpen = @"interstitialAdFailedToOpen";
+static NSString *const kEventAdClosed = @"interstitialAdClosed";
+static NSString *const kEventAdLeftApplication = @"interstitialAdLeftApplication";
 
 @implementation RNAdMobInterstitial
 {

--- a/ios/RNAdMobRewarded.m
+++ b/ios/RNAdMobRewarded.m
@@ -6,13 +6,13 @@
 #import "RCTUtils.h"
 #endif
 
-static NSString *const kEventAdLoaded = @"adLoaded";
-static NSString *const kEventAdFailedToLoad = @"adFailedToLoad";
-static NSString *const kEventAdOpened = @"adOpened";
-static NSString *const kEventAdClosed = @"adClosed";
-static NSString *const kEventAdLeftApplication = @"adLeftApplication";
-static NSString *const kEventRewarded = @"rewarded";
-static NSString *const kEventVideoStarted = @"videoStarted";
+static NSString *const kEventAdLoaded = @"rewardedVideoAdLoaded";
+static NSString *const kEventAdFailedToLoad = @"rewardedVideoAdFailedToLoad";
+static NSString *const kEventAdOpened = @"rewardedVideoAdOpened";
+static NSString *const kEventAdClosed = @"rewardedVideoAdClosed";
+static NSString *const kEventAdLeftApplication = @"rewardedVideoAdLeftApplication";
+static NSString *const kEventRewarded = @"rewardedVideoAdRewarded";
+static NSString *const kEventVideoStarted = @"rewardedVideoAdVideoStarted";
 
 @implementation RNAdMobRewarded
 {


### PR DESCRIPTION
since events are not scoped to a module they did clash.

The pattern used here is adopted from React Native's NetInfo module; https://github.com/facebook/react-native/blob/1e8f3b11027fe0a7514b4fc97d0798d3c64bc895/Libraries/Network/NetInfo.js#L210