### PR TITLE
Fix: add checking for null to avoid exception when .setAdUnitId is set twice

### DIFF
--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
@@ -106,7 +106,9 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setAdUnitID(String adUnitID) {
-        mInterstitialAd.setAdUnitId(adUnitID);
+        if (mInterstitialAd.getAdUnitId() == null) {
+            mInterstitialAd.setAdUnitId(adUnitID);
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
Closes https://github.com/sbugert/react-native-admob/issues/79

A two line fix that helps a lot, since all state is lost after reloading the JS code, so we can't keep track of whether this has been set or not.