### PR TITLE
Performance & React Native 0.51 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "es6": true
+    "es6": true,
+    "node": true
   },
   "extends": ["eslint:recommended", "plugin:react/recommended"],
   "parser": "babel-eslint",
@@ -8,7 +9,8 @@
     "ecmaVersion": 6
   },
   "plugins": [
-    "react"
+    "react",
+    "react-native"
   ],
   "rules": {
     "comma-dangle": ["error", "always-multiline"],

--- a/Example/.flowconfig
+++ b/Example/.flowconfig
@@ -37,12 +37,12 @@ suppress_type=$FlowFixMeProps
 suppress_type=$FlowFixMeState
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(5[0-6]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(5[0-6]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(5[0-7]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(5[0-7]\\|[1-4][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 unsafe.enable_getters_and_setters=true
 
 [version]
-^0.56.0
+^0.57.0

--- a/Example/package.json
+++ b/Example/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "16.0.0",
-    "react-native": "0.50.3",
+    "react-native": "0.51.0",
     "react-native-admob": "file:.."
   },
   "devDependencies": {

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -259,6 +259,14 @@ babel-generator@^6.18.0, babel-generator@^6.24.1, babel-generator@^6.26.0:
     source-map "^0.5.6"
     trim-right "^1.0.1"
 
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
 babel-helper-builder-react-jsx@^6.24.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz#39ff8313b75c8b65dceff1f31d383e0ff2a408a0"
@@ -284,6 +292,14 @@ babel-helper-define-map@^6.24.1:
     babel-runtime "^6.26.0"
     babel-types "^6.26.0"
     lodash "^4.17.4"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
@@ -414,6 +430,10 @@ babel-plugin-syntax-class-properties@^6.5.0, babel-plugin-syntax-class-propertie
 babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
 babel-plugin-syntax-flow@^6.18.0, babel-plugin-syntax-flow@^6.5.0, babel-plugin-syntax-flow@^6.8.0:
   version "6.18.0"
@@ -589,6 +609,14 @@ babel-plugin-transform-es3-property-literals@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz#b2078d5842e22abf40f73e8cde9cd3711abd5758"
   dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-exponentiation-operator@^6.5.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
 babel-plugin-transform-flow-strip-types@^6.21.0, babel-plugin-transform-flow-strip-types@^6.5.0, babel-plugin-transform-flow-strip-types@^6.8.0:
@@ -2699,7 +2727,7 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-metro-bundler@^0.20.1:
+metro-bundler@^0.20.0:
   version "0.20.3"
   resolved "https://registry.yarnpkg.com/metro-bundler/-/metro-bundler-0.20.3.tgz#0ded01b64e8963117017b106f75b83cfc34f3656"
   dependencies:
@@ -3312,13 +3340,13 @@ react-devtools-core@^2.5.0:
     ws "^2.0.3"
 
 "react-native-admob@file:..":
-  version "2.0.0-beta.2"
+  version "2.0.0-beta.3"
   dependencies:
     prop-types "^15.5.10"
 
-react-native@0.50.3:
-  version "0.50.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.50.3.tgz#91282bd5356cc7d794969cdc443cc764389b9af4"
+react-native@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.51.0.tgz#fe25934b3030fd323f3ca1a70f034133465955ed"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"
@@ -3326,6 +3354,7 @@ react-native@0.50.3:
     babel-plugin-syntax-trailing-function-commas "^6.20.0"
     babel-plugin-transform-async-to-generator "6.16.0"
     babel-plugin-transform-class-properties "^6.18.0"
+    babel-plugin-transform-exponentiation-operator "^6.5.0"
     babel-plugin-transform-flow-strip-types "^6.21.0"
     babel-plugin-transform-object-rest-spread "^6.20.2"
     babel-register "^6.24.1"
@@ -3346,7 +3375,7 @@ react-native@0.50.3:
     graceful-fs "^4.1.3"
     inquirer "^3.0.6"
     lodash "^4.16.6"
-    metro-bundler "^0.20.1"
+    metro-bundler "^0.20.0"
     mime "^1.3.4"
     minimist "^1.2.0"
     mkdirp "^0.5.1"
@@ -3362,7 +3391,7 @@ react-native@0.50.3:
     react-clone-referenced-element "^1.0.1"
     react-devtools-core "^2.5.0"
     react-timer-mixin "^0.13.2"
-    regenerator-runtime "^0.9.5"
+    regenerator-runtime "^0.11.0"
     rimraf "^2.5.4"
     semver "^5.0.3"
     shell-quote "1.6.1"
@@ -3465,10 +3494,6 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
-
-regenerator-runtime@^0.9.5:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
 
 regenerator-transform@^0.10.0:
   version "0.10.1"

--- a/RNAdMobBanner.js
+++ b/RNAdMobBanner.js
@@ -59,11 +59,7 @@ class AdMobBanner extends Component {
   }
 }
 
-Object.defineProperty(AdMobBanner, 'simulatorId', {
-  get() {
-    return UIManager.RNGADBannerView.Constants.simulatorId;
-  },
-});
+AdMobBanner.simulatorId = 'SIMULATOR';
 
 AdMobBanner.propTypes = {
   ...ViewPropTypes,

--- a/RNAdMobInterstitial.js
+++ b/RNAdMobInterstitial.js
@@ -61,4 +61,5 @@ export default {
   addEventListener,
   removeEventListener,
   removeAllListeners,
+  simulatorId: 'SIMULATOR',
 };

--- a/RNAdMobInterstitial.js
+++ b/RNAdMobInterstitial.js
@@ -30,9 +30,10 @@ const addEventListener = (event, handler) => {
     }
     _subscriptions.set(handler, listener);
     return {
-      remove: () => removeEventListener(event, handler)
+      remove: () => removeEventListener(event, handler),
     };
   } else {
+    // eslint-disable-next-line no-console
     console.warn(`Trying to subscribe to unknown event: "${event}"`);
     return {
       remove: () => {},

--- a/RNAdMobRewarded.js
+++ b/RNAdMobRewarded.js
@@ -32,9 +32,10 @@ const addEventListener = (event, handler) => {
     }
     _subscriptions.set(handler, listener);
     return {
-      remove: () => removeEventListener(event, handler)
+      remove: () => removeEventListener(event, handler),
     };
   } else {
+    // eslint-disable-next-line no-console
     console.warn(`Trying to subscribe to unknown event: "${event}"`);
     return {
       remove: () => {},

--- a/RNAdMobRewarded.js
+++ b/RNAdMobRewarded.js
@@ -63,4 +63,5 @@ export default {
   addEventListener,
   removeEventListener,
   removeAllListeners,
+  simulatorId: 'SIMULATOR',
 };

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -68,11 +68,7 @@ class PublisherBanner extends Component {
   }
 }
 
-Object.defineProperty(PublisherBanner, 'simulatorId', {
-  get() {
-    return UIManager.RNDFPBannerView.Constants.simulatorId;
-  },
-});
+PublisherBanner.simulatorId = 'SIMULATOR';
 
 PublisherBanner.propTypes = {
   ...ViewPropTypes,

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobBannerViewManager.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobBannerViewManager.java
@@ -128,7 +128,11 @@ class ReactAdView extends ReactViewGroup {
         AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
         if (testDevices != null) {
             for (int i = 0; i < testDevices.length; i++) {
-                adRequestBuilder.addTestDevice(testDevices[i]);
+                String testDevice = testDevices[i];
+                if (testDevice == "SIMULATOR") {
+                    testDevice = AdRequest.DEVICE_ID_EMULATOR;
+                }
+                adRequestBuilder.addTestDevice(testDevice);
             }
         }
         AdRequest adRequest = adRequestBuilder.build();
@@ -245,14 +249,6 @@ public class RNAdMobBannerViewManager extends ViewGroupManager<ReactAdView> {
             default:
                 return AdSize.BANNER;
         }
-    }
-
-    @Nullable
-    @Override
-    public Map<String, Object> getExportedViewConstants() {
-        final Map<String, Object> constants = new HashMap<>();
-        constants.put("simulatorId", AdRequest.DEVICE_ID_EMULATOR);
-        return constants;
     }
 
     @Nullable

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
@@ -130,7 +130,11 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
                     AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
                     if (testDevices != null) {
                         for (int i = 0; i < testDevices.length; i++) {
-                            adRequestBuilder.addTestDevice(testDevices[i]);
+                            String testDevice = testDevices[i];
+                            if (testDevice == "SIMULATOR") {
+                                testDevice = AdRequest.DEVICE_ID_EMULATOR;
+                            }
+                            adRequestBuilder.addTestDevice(testDevice);
                         }
                     }
                     AdRequest adRequest = adRequestBuilder.build();
@@ -163,13 +167,5 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
                 callback.invoke(mInterstitialAd.isLoaded());
             }
         });
-    }
-
-    @javax.annotation.Nullable
-    @Override
-    public Map<String, Object> getConstants() {
-        final Map<String, Object> constants = new HashMap<>();
-        constants.put("simulatorId", AdRequest.DEVICE_ID_EMULATOR);
-        return constants;
     }
 }

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -148,7 +148,11 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
 
                     if (testDevices != null) {
                         for (int i = 0; i < testDevices.length; i++) {
-                            adRequestBuilder.addTestDevice(testDevices[i]);
+                            String testDevice = testDevices[i];
+                            if (testDevice == "SIMULATOR") {
+                                testDevice = AdRequest.DEVICE_ID_EMULATOR;
+                            }
+                            adRequestBuilder.addTestDevice(testDevice);
                         }
                     }
 

--- a/android/src/main/java/com/sbugert/rnadmob/RNPublisherBannerViewManager.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNPublisherBannerViewManager.java
@@ -148,7 +148,11 @@ class ReactPublisherAdView extends ReactViewGroup implements AppEventListener {
         PublisherAdRequest.Builder adRequestBuilder = new PublisherAdRequest.Builder();
         if (testDevices != null) {
             for (int i = 0; i < testDevices.length; i++) {
-                adRequestBuilder.addTestDevice(testDevices[i]);
+                String testDevice = testDevices[i];
+                if (testDevice == "SIMULATOR") {
+                    testDevice = PublisherAdRequest.DEVICE_ID_EMULATOR;
+                }
+                adRequestBuilder.addTestDevice(testDevice);
             }
         }
         PublisherAdRequest adRequest = adRequestBuilder.build();
@@ -293,14 +297,6 @@ public class RNPublisherBannerViewManager extends ViewGroupManager<ReactPublishe
             default:
                 return AdSize.BANNER;
         }
-    }
-
-    @Nullable
-    @Override
-    public Map<String, Object> getExportedViewConstants() {
-        final Map<String, Object> constants = new HashMap<>();
-        constants.put("simulatorId", PublisherAdRequest.DEVICE_ID_EMULATOR);
-        return constants;
     }
 
     @Nullable

--- a/index.js
+++ b/index.js
@@ -1,6 +1,15 @@
-import AdMobBanner from './RNAdMobBanner';
-import AdMobInterstitial from './RNAdMobInterstitial';
-import PublisherBanner from './RNPublisherBanner';
-import AdMobRewarded from './RNAdMobRewarded';
-
-export { AdMobBanner, AdMobInterstitial, PublisherBanner, AdMobRewarded };
+/* eslint-disable global-require */
+module.exports = {
+  get AdMobBanner() {
+    return require('./RNAdMobBanner').default;
+  },
+  get AdMobInterstitial() {
+    return require('./RNAdMobInterstitial').default;
+  },
+  get PublisherBanner() {
+    return require('./RNPublisherBanner').default;
+  },
+  get AdMobRewarded() {
+    return require('./RNAdMobRewarded').default;
+  },
+};

--- a/ios/RNAdMobInterstitial.m
+++ b/ios/RNAdMobInterstitial.m
@@ -1,4 +1,5 @@
 #import "RNAdMobInterstitial.h"
+#import "RNAdMobUtils.h"
 
 #if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
@@ -50,7 +51,7 @@ RCT_EXPORT_METHOD(setAdUnitID:(NSString *)adUnitID)
 
 RCT_EXPORT_METHOD(setTestDevices:(NSArray *)testDevices)
 {
-    _testDevices = testDevices;
+    _testDevices = RNAdMobProcessTestDevices(testDevices, kGADSimulatorID);
 }
 
 RCT_EXPORT_METHOD(requestAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
@@ -87,13 +88,6 @@ RCT_EXPORT_METHOD(showAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRej
 RCT_EXPORT_METHOD(isReady:(RCTResponseSenderBlock)callback)
 {
     callback(@[[NSNumber numberWithBool:[_interstitial isReady]]]);
-}
-
-- (NSDictionary<NSString *,id> *)constantsToExport
-{
-    return @{
-             @"simulatorId": kGADSimulatorID
-             };
 }
 
 - (void)startObserving

--- a/ios/RNAdMobInterstitial.m
+++ b/ios/RNAdMobInterstitial.m
@@ -29,6 +29,11 @@ static NSString *const kEventAdLeftApplication = @"interstitialAdLeftApplication
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents

--- a/ios/RNAdMobManager.xcodeproj/project.pbxproj
+++ b/ios/RNAdMobManager.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0CB8C04B1D913E00002BC3EF /* RNDFPBannerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */; };
 		0CB8C04E1D9143A6002BC3EF /* RNDFPBannerViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 0CB8C04D1D9143A6002BC3EF /* RNDFPBannerViewManager.m */; };
+		5E2419841FE11E0F00C6B738 /* RNAdMobUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E2419831FE11E0F00C6B738 /* RNAdMobUtils.m */; };
 		5E86A6471F126FCE008013EB /* RCTConvert+GADAdSize.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E86A6461F126FCE008013EB /* RCTConvert+GADAdSize.m */; };
 		A90F2F8C1D50AEF200F2A2E3 /* RNAdMobRewarded.m in Sources */ = {isa = PBXBuildFile; fileRef = A90F2F8B1D50AEF200F2A2E3 /* RNAdMobRewarded.m */; };
 		A962C2531CB27DBD00E508A1 /* RNAdMobInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = A962C2521CB27DBD00E508A1 /* RNAdMobInterstitial.m */; };
@@ -33,6 +34,8 @@
 		0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNDFPBannerView.m; sourceTree = SOURCE_ROOT; };
 		0CB8C04C1D9143A6002BC3EF /* RNDFPBannerViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNDFPBannerViewManager.h; sourceTree = SOURCE_ROOT; };
 		0CB8C04D1D9143A6002BC3EF /* RNDFPBannerViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNDFPBannerViewManager.m; sourceTree = SOURCE_ROOT; };
+		5E2419831FE11E0F00C6B738 /* RNAdMobUtils.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNAdMobUtils.m; sourceTree = SOURCE_ROOT; };
+		5E2419851FE11F1200C6B738 /* RNAdMobUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNAdMobUtils.h; sourceTree = SOURCE_ROOT; };
 		5E86A6451F126FCE008013EB /* RCTConvert+GADAdSize.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTConvert+GADAdSize.h"; sourceTree = SOURCE_ROOT; };
 		5E86A6461F126FCE008013EB /* RCTConvert+GADAdSize.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTConvert+GADAdSize.m"; sourceTree = SOURCE_ROOT; };
 		A90F2F8A1D50AEF200F2A2E3 /* RNAdMobRewarded.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAdMobRewarded.h; sourceTree = SOURCE_ROOT; };
@@ -86,6 +89,8 @@
 				A962C2521CB27DBD00E508A1 /* RNAdMobInterstitial.m */,
 				0CB8C0491D913E00002BC3EF /* RNDFPBannerView.h */,
 				0CB8C04A1D913E00002BC3EF /* RNDFPBannerView.m */,
+				5E2419831FE11E0F00C6B738 /* RNAdMobUtils.m */,
+				5E2419851FE11F1200C6B738 /* RNAdMobUtils.h */,
 				A90F2F8A1D50AEF200F2A2E3 /* RNAdMobRewarded.h */,
 				A90F2F8B1D50AEF200F2A2E3 /* RNAdMobRewarded.m */,
 				5E86A6451F126FCE008013EB /* RCTConvert+GADAdSize.h */,
@@ -156,6 +161,7 @@
 				A90F2F8C1D50AEF200F2A2E3 /* RNAdMobRewarded.m in Sources */,
 				A96DA7841C146DA600FC639B /* RNGADBannerView.m in Sources */,
 				A96DA7851C146DA600FC639B /* RNGADBannerViewManager.m in Sources */,
+				5E2419841FE11E0F00C6B738 /* RNAdMobUtils.m in Sources */,
 				5E86A6471F126FCE008013EB /* RCTConvert+GADAdSize.m in Sources */,
 				0CB8C04E1D9143A6002BC3EF /* RNDFPBannerViewManager.m in Sources */,
 			);

--- a/ios/RNAdMobRewarded.m
+++ b/ios/RNAdMobRewarded.m
@@ -1,4 +1,5 @@
 #import "RNAdMobRewarded.h"
+#import "RNAdMobUtils.h"
 
 #if __has_include(<React/RCTUtils.h>)
 #import <React/RCTUtils.h>
@@ -51,7 +52,7 @@ RCT_EXPORT_METHOD(setAdUnitID:(NSString *)adUnitID)
 
 RCT_EXPORT_METHOD(setTestDevices:(NSArray *)testDevices)
 {
-    _testDevices = testDevices;
+    _testDevices = RNAdMobProcessTestDevices(testDevices, kGADSimulatorID);
 }
 
 RCT_EXPORT_METHOD(requestAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
@@ -82,13 +83,6 @@ RCT_EXPORT_METHOD(showAd:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRej
 RCT_EXPORT_METHOD(isReady:(RCTResponseSenderBlock)callback)
 {
     callback(@[[NSNumber numberWithBool:[[GADRewardBasedVideoAd sharedInstance] isReady]]]);
-}
-
-- (NSDictionary<NSString *,id> *)constantsToExport
-{
-    return @{
-             @"simulatorId": kGADSimulatorID
-             };
 }
 
 - (void)startObserving

--- a/ios/RNAdMobRewarded.m
+++ b/ios/RNAdMobRewarded.m
@@ -29,6 +29,11 @@ static NSString *const kEventVideoStarted = @"rewardedVideoAdVideoStarted";
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents

--- a/ios/RNAdMobUtils.h
+++ b/ios/RNAdMobUtils.h
@@ -1,0 +1,3 @@
+#import <Foundation/Foundation.h>
+
+NSArray *__nullable RNAdMobProcessTestDevices(NSArray *__nullable testDevices, id _Nonnull simulatorId);

--- a/ios/RNAdMobUtils.m
+++ b/ios/RNAdMobUtils.m
@@ -1,0 +1,16 @@
+#import "RNAdMobUtils.h"
+
+NSArray *__nullable RNAdMobProcessTestDevices(NSArray *__nullable testDevices, id _Nonnull simulatorId)
+{
+    if (testDevices == NULL) {
+        return testDevices;
+    }
+    NSInteger index = [testDevices indexOfObject:@"SIMULATOR"];
+    if (index == NSNotFound) {
+        return testDevices;
+    }
+    NSMutableArray *values = [testDevices mutableCopy];
+    [values removeObjectAtIndex:index];
+    [values addObject:simulatorId];
+    return values;
+}

--- a/ios/RNDFPBannerView.m
+++ b/ios/RNDFPBannerView.m
@@ -1,4 +1,5 @@
 #import "RNDFPBannerView.h"
+#import "RNAdMobUtils.h"
 
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
@@ -59,7 +60,7 @@
 
 - (void)setValidAdSizes:(NSArray *)adSizes
 {
-    NSMutableArray *validAdSizes = [[NSMutableArray alloc] initWithCapacity:adSizes.count];
+    __block NSMutableArray *validAdSizes = [[NSMutableArray alloc] initWithCapacity:adSizes.count];
     [adSizes enumerateObjectsUsingBlock:^(id jsonValue, NSUInteger idx, __unused BOOL *stop) {
         GADAdSize adSize = [RCTConvert GADAdSize:jsonValue];
         if (GADAdSizeEqualToSize(adSize, kGADAdSizeInvalid)) {
@@ -69,6 +70,11 @@
         }
     }];
     _bannerView.validAdSizes = validAdSizes;
+}
+
+- (void)setTestDevices:(NSArray *)testDevices
+{
+    _testDevices = RNAdMobProcessTestDevices(testDevices, kDFPSimulatorID);
 }
 
 -(void)layoutSubviews

--- a/ios/RNDFPBannerViewManager.m
+++ b/ios/RNDFPBannerViewManager.m
@@ -20,11 +20,6 @@ RCT_EXPORT_MODULE();
   return [RNDFPBannerView new];
 }
 
-- (dispatch_queue_t)methodQueue
-{
-  return dispatch_get_main_queue();
-}
-
 RCT_EXPORT_METHOD(loadBanner:(nonnull NSNumber *)reactTag)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNDFPBannerView *> *viewRegistry) {

--- a/ios/RNDFPBannerViewManager.m
+++ b/ios/RNDFPBannerViewManager.m
@@ -50,11 +50,4 @@ RCT_EXPORT_VIEW_PROPERTY(onAdOpened, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdClosed, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdLeftApplication, RCTBubblingEventBlock)
 
-- (NSDictionary<NSString *,id> *)constantsToExport
-{
-    return @{
-        @"simulatorId": kGADSimulatorID
-    };
-}
-
 @end

--- a/ios/RNGADBannerView.m
+++ b/ios/RNGADBannerView.m
@@ -1,4 +1,5 @@
 #import "RNGADBannerView.h"
+#import "RNAdMobUtils.h"
 
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
@@ -58,6 +59,11 @@
     GADRequest *request = [GADRequest request];
     request.testDevices = _testDevices;
     [_bannerView loadRequest:request];
+}
+
+- (void)setTestDevices:(NSArray *)testDevices
+{
+    _testDevices = RNAdMobProcessTestDevices(testDevices, kGADSimulatorID);
 }
 
 -(void)layoutSubviews

--- a/ios/RNGADBannerViewManager.m
+++ b/ios/RNGADBannerViewManager.m
@@ -21,11 +21,6 @@ RCT_EXPORT_MODULE();
     return [RNGADBannerView new];
 }
 
-- (dispatch_queue_t)methodQueue
-{
-    return dispatch_get_main_queue();
-}
-
 RCT_EXPORT_METHOD(loadBanner:(nonnull NSNumber *)reactTag)
 {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNGADBannerView *> *viewRegistry) {

--- a/ios/RNGADBannerViewManager.m
+++ b/ios/RNGADBannerViewManager.m
@@ -50,11 +50,4 @@ RCT_EXPORT_VIEW_PROPERTY(onAdOpened, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdClosed, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onAdLeftApplication, RCTBubblingEventBlock)
 
-- (NSDictionary<NSString *,id> *)constantsToExport
-{
-    return @{
-             @"simulatorId": kGADSimulatorID
-             };
-}
-
 @end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-admob",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-beta.4",
   "description": "A react-native component for Google AdMob banners and interstitials",
   "author": "Simon Bugert <simon.bugert@gmail.com>",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^4.3.0",
-    "eslint-plugin-react": "^7.1.0"
+    "eslint-plugin-react": "^7.1.0",
+    "eslint-plugin-react-native": "^3.2.0"
   }
 }


### PR DESCRIPTION
Using `constantsToExport` on iOS prevents the module to be lazy loaded, so the value of `simutatorId` is now set in javascript, and mapped to the native value when used.

Also the javascript index has been updated to require the javascript modules only when used.