### PR TITLE
Fix: make sure requestPromise is only invoked once + crash when isLoaded() is called before requestAd()

### DIFF
--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
@@ -81,7 +81,10 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
                         WritableMap error = Arguments.createMap();
                         event.putString("message", errorMessage);
                         sendEvent(EVENT_AD_FAILED_TO_LOAD, event);
-                        mRequestAdPromise.reject(errorString, errorMessage);
+                        if (mRequestAdPromise != null) {
+                            mRequestAdPromise.reject(errorString, errorMessage);
+                            mRequestAdPromise = null;
+                        }
                     }
                     @Override
                     public void onAdLeftApplication() {
@@ -90,7 +93,10 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
                     @Override
                     public void onAdLoaded() {
                         sendEvent(EVENT_AD_LOADED, null);
-                        mRequestAdPromise.resolve(null);
+                        if (mRequestAdPromise != null) {
+                          mRequestAdPromise.resolve(null);
+                          mRequestAdPromise = null;
+                        }
                     }
                     @Override
                     public void onAdOpened() {
@@ -126,6 +132,7 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
                 if (mInterstitialAd.isLoaded() || mInterstitialAd.isLoading()) {
                     promise.reject("E_AD_ALREADY_LOADED", "Ad is already loaded.");
                 } else {
+                  
                     mRequestAdPromise = promise;
                     AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
                     if (testDevices != null) {

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobInterstitialAdModule.java
@@ -132,7 +132,6 @@ public class RNAdMobInterstitialAdModule extends ReactContextBaseJavaModule {
                 if (mInterstitialAd.isLoaded() || mInterstitialAd.isLoading()) {
                     promise.reject("E_AD_ALREADY_LOADED", "Ad is already loaded.");
                 } else {
-                  
                     mRequestAdPromise = promise;
                     AdRequest.Builder adRequestBuilder = new AdRequest.Builder();
                     if (testDevices != null) {

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -170,7 +170,7 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                if (mRewardedVideoAd.isLoaded()) {
+                if (mRewardedVideoAd != null && mRewardedVideoAd.isLoaded()) {
                     mRewardedVideoAd.show();
                     promise.resolve(null);
                 } else {
@@ -185,7 +185,11 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
         new Handler(Looper.getMainLooper()).post(new Runnable() {
             @Override
             public void run() {
-                callback.invoke(mRewardedVideoAd.isLoaded());
+                if (mRewardedVideoAd != null) {
+                    callback.invoke(mRewardedVideoAd.isLoaded());
+                } else {
+                    callback.invoke(false);
+                }
             }
         });
     }

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -62,7 +62,10 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
     @Override
     public void onRewardedVideoAdLoaded() {
         sendEvent(EVENT_AD_LOADED, null);
-        mRequestAdPromise.resolve(null);
+        if (mRequestAdPromise != null) {
+          mRequestAdPromise.resolve(null);
+          mRequestAdPromise = null;
+        }
     }
 
     @Override
@@ -111,7 +114,10 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
         WritableMap error = Arguments.createMap();
         event.putString("message", errorMessage);
         sendEvent(EVENT_AD_FAILED_TO_LOAD, event);
-        mRequestAdPromise.reject(errorString, errorMessage);
+        if (mRequestAdPromise != null) {
+          mRequestAdPromise.reject(errorString, errorMessage);
+          mRequestAdPromise = null;
+        }
     }
 
     private void sendEvent(String eventName, @Nullable WritableMap params) {


### PR DESCRIPTION
Closes https://github.com/sbugert/react-native-admob/issues/229

Give us a few days to test all of this in production - soon we can confirm that the crashes are gone.