### PR TITLE
Override abstract method onRewardedVideoCompleted()

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,11 @@ Unfortunately, events are not consistent across iOS and Android. To have one uni
       <td><code>onRewardedVideoStarted</code></td>
     </tr>
     <tr>
+      <td><code>videoCompleted</code></td>
+      <td><code>rewardBasedVideoAdDidCompletePlaying</code></td>
+      <td><code>rewardedVideoAdVideoCompleted</code></td>
+    </tr>
+    <tr>
       <td><code>adClosed</code></td>
       <td><code>rewardBasedVideoAdDidClose</code></td>
       <td><code>onRewardedVideoAdClosed</code></td>

--- a/RNAdMobRewarded.js
+++ b/RNAdMobRewarded.js
@@ -17,6 +17,7 @@ const eventMap = {
   adLeftApplication: 'rewardedVideoAdLeftApplication',
   rewarded: 'rewardedVideoAdRewarded',
   videoStarted: 'rewardedVideoAdVideoStarted',
+  videoCompleted: 'rewardedVideoAdVideoCompleted',
 };
 
 const _subscriptions = new Map();

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -33,7 +33,7 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
     public static final String EVENT_AD_LEFT_APPLICATION = "rewardedVideoAdLeftApplication";
     public static final String EVENT_REWARDED = "rewardedVideoAdRewarded";
     public static final String EVENT_VIDEO_STARTED = "rewardedVideoAdVideoStarted";
-
+    public static final String EVENT_VIDEO_COMPLETED = "rewardedVideoAdVideoCompleted";
     RewardedVideoAd mRewardedVideoAd;
     String adUnitID;
     String[] testDevices;
@@ -83,6 +83,11 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
     @Override
     public void onRewardedVideoAdLeftApplication() {
         sendEvent(EVENT_AD_LEFT_APPLICATION, null);
+    }
+
+    @Override
+    public void onRewardedVideoCompleted() {
+        sendEvent(EVENT_VIDEO_COMPLETED, null);
     }
 
     @Override

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -34,6 +34,7 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
     public static final String EVENT_REWARDED = "rewardedVideoAdRewarded";
     public static final String EVENT_VIDEO_STARTED = "rewardedVideoAdVideoStarted";
     public static final String EVENT_VIDEO_COMPLETED = "rewardedVideoAdVideoCompleted";
+
     RewardedVideoAd mRewardedVideoAd;
     String adUnitID;
     String[] testDevices;

--- a/ios/RNAdMobRewarded.m
+++ b/ios/RNAdMobRewarded.m
@@ -13,6 +13,7 @@ static NSString *const kEventAdClosed = @"rewardedVideoAdClosed";
 static NSString *const kEventAdLeftApplication = @"rewardedVideoAdLeftApplication";
 static NSString *const kEventRewarded = @"rewardedVideoAdRewarded";
 static NSString *const kEventVideoStarted = @"rewardedVideoAdVideoStarted";
+static NSString *const kEventVideoCompleted = @"rewardedVideoAdVideoCompleted";
 
 @implementation RNAdMobRewarded
 {
@@ -39,7 +40,8 @@ RCT_EXPORT_MODULE();
              kEventAdOpened,
              kEventVideoStarted,
              kEventAdClosed,
-             kEventAdLeftApplication ];
+             kEventAdLeftApplication,
+             kEventVideoCompleted ];
 }
 
 #pragma mark exported methods
@@ -129,6 +131,13 @@ RCT_EXPORT_METHOD(isReady:(RCTResponseSenderBlock)callback)
 {
     if (hasListeners) {
         [self sendEventWithName:kEventVideoStarted body:nil];
+    }
+}
+
+- (void)rewardBasedVideoAdDidCompletePlaying:(__unused GADRewardBasedVideoAd *)rewardBasedVideoAd
+{
+    if (hasListeners) {
+        [self sendEventWithName:kEventVideoCompleted body:nil];
     }
 }
 


### PR DESCRIPTION
While I was debugging in android, I'd got an error message that RNAdMobRewardedVideoAdModule is not abstract and does not override abstract method onRewardedVideoCompleted() in RewardedVideoAdListener
public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule implements RewardedVideoAdListener 

So I had implemented this method for android 

![screen shot 2018-03-23 at 1 23 55 pm](https://user-images.githubusercontent.com/5790268/37811492-f008d404-2e9d-11e8-899a-5dc484631a02.png)



