### PR TITLE
Fix "Argument list too long: recursive header expansion failed" issue

### DIFF
--- a/ios/RNAdMobManager.xcodeproj/project.pbxproj
+++ b/ios/RNAdMobManager.xcodeproj/project.pbxproj
@@ -247,7 +247,7 @@
 		A96DA77E1C146D7200FC639B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/Pods/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",
@@ -261,7 +261,7 @@
 		A96DA77F1C146D7200FC639B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/**";
+				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../../../ios/Pods/**";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../../../node_modules/react-native/React/**",


### PR DESCRIPTION
Fixes #209.

See [this comment](https://github.com/sbugert/react-native-admob/issues/209#issuecomment-344127065), and [this comment](https://github.com/tinycreative/react-native-intercom/issues/40#issuecomment-352094143).