### PR TITLE
Update Google Play's target API level requirement starting August 1, 2018

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 27
     }
     buildTypes {
         release {
@@ -17,6 +17,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-ads:+'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.google.android.gms:play-services-ads:+'
 }


### PR DESCRIPTION
and Fix `WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.`

You can read more about the requirements here https://developer.android.com/distribute/best-practices/develop/target-sdk