### PR TITLE
fix Illegal callback invocation from native module crash

### DIFF
--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -63,7 +63,10 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
     @Override
     public void onRewardedVideoAdLoaded() {
         sendEvent(EVENT_AD_LOADED, null);
-        mRequestAdPromise.resolve(null);
+        if (mRequestAdPromise != null) {
+          mRequestAdPromise.resolve(null);
+          mRequestAdPromise = null;
+        }
     }
 
     @Override
@@ -117,7 +120,11 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
         WritableMap error = Arguments.createMap();
         event.putString("message", errorMessage);
         sendEvent(EVENT_AD_FAILED_TO_LOAD, event);
-        mRequestAdPromise.reject(errorString, errorMessage);
+
+        if (mRequestAdPromise != null) {
+          mRequestAdPromise.reject(errorString, errorMessage);
+          mRequestAdPromise = null;
+        }
     }
 
     private void sendEvent(String eventName, @Nullable WritableMap params) {

--- a/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNAdMobRewardedVideoAdModule.java
@@ -120,7 +120,6 @@ public class RNAdMobRewardedVideoAdModule extends ReactContextBaseJavaModule imp
         WritableMap error = Arguments.createMap();
         event.putString("message", errorMessage);
         sendEvent(EVENT_AD_FAILED_TO_LOAD, event);
-
         if (mRequestAdPromise != null) {
           mRequestAdPromise.reject(errorString, errorMessage);
           mRequestAdPromise = null;


### PR DESCRIPTION
`
java.lang.RuntimeException: Illegal callback invocation from native module. This callback type only permits a single invocation from native code.
	at com.facebook.react.bridge.CallbackImpl.invoke(CallbackImpl.java:30)
	at com.facebook.react.bridge.PromiseImpl.reject(PromiseImpl.java:70)
	at com.facebook.react.bridge.PromiseImpl.reject(PromiseImpl.java:38)
	at com.sbugert.rnadmob.RNAdMobRewardedVideoAdModule.onRewardedVideoAdFailedToLoad(RNAdMobRewardedVideoAdModule.java:120)
	at com.google.android.gms.internal.ads.zzahj.onRewardedVideoAdFailedToLoad(Unknown Source)
	at com.google.android.gms.internal.ads.zzahf.dispatchTransaction(Unknown Source)
	at com.google.android.gms.internal.ads.zzek.onTransact(Unknown Source)
	at android.os.Binder.transact(Binder.java:499)
	at mt.b(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):20)
	at com.google.android.gms.ads.internal.reward.client.n.a(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):24)
	at com.google.android.gms.ads.internal.a.a(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):430)
	at com.google.android.gms.ads.internal.a.a(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):420)
	at com.google.android.gms.ads.internal.a.b(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):188)
	at com.google.android.gms.ads.internal.d.b(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):52)
	at com.google.android.gms.ads.internal.reward.g.run(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):2)
	at android.os.Handler.handleCallback(Handler.java:751)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at com.google.android.gms.ads.internal.util.f.dispatchMessage(:com.google.android.gms.dynamite_adsdynamite@12874021@12.8.74 (040306-204998136):9)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6312)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:872)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:762)
`

fix it