### PR TITLE
Update gradle tooling

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
     }
     buildTypes {
         release {
@@ -17,6 +21,6 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-ads:+'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.google.android.gms:play-services-ads:+'
 }


### PR DESCRIPTION
Updates gradle to use React-Native and Android's latest standards for improving dependency management.

Resolves #251:

* By changing `compile` to `implementation`, we comply with [Android's new dependency configurations](http://d.android.com/r/tools/update-dependency-configurations.html). `implementation` is slightly faster than `api`, and the purpose of this library is to expose admob, not its underlying dependencies (like Google Play), to anyone who adds it to their project.
* By using default values for target SDK, etc., we fix dependency resolution issues that may occur when combining with other native libs. The new gradle template generated by the various CLI tools include an `ext` block to add these default properties, but if anyone is using older versions and does not have that block, this behavior will not change for them. (In case anyone wants to manually add this to an existing project, [this is the best doc I've found.](https://github.com/transistorsoft/react-native-background-fetch/wiki/Solving-Android-Gradle-Conflicts#step-1--open_file_folder-androidbuildgradle))
