### PR TITLE
Fixing warning : Accessing view manager configs directly off UIManage…

### DIFF
--- a/RNAdMobBanner.js
+++ b/RNAdMobBanner.js
@@ -27,7 +27,7 @@ class AdMobBanner extends Component {
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this._bannerView),
-      UIManager.RNGADBannerView.Commands.loadBanner,
+      UIManager.getViewManagerConfig('RNGADBannerView').Commands.loadBanner,
       null,
     );
   }


### PR DESCRIPTION
Fixed : Accessing view manager configs directly off UIManager via UIManager[‘RNGADBannerView’] is no longer supported. Use UIManager.getViewManagerConfig(‘RNGADBannerView’) instead.