### PR TITLE
Warning: Accessing view manager configs directly of UIManage

### DIFF
--- a/RNAdMobBanner.js
+++ b/RNAdMobBanner.js
@@ -27,7 +27,7 @@ class AdMobBanner extends Component {
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this._bannerView),
-      UIManager.RNGADBannerView.Commands.loadBanner,
+      UIManager.getViewManagerConfig('RNGADBannerView').Commands.loadBanner,
       null,
     );
   }

--- a/RNPublisherBanner.js
+++ b/RNPublisherBanner.js
@@ -28,7 +28,7 @@ class PublisherBanner extends Component {
   loadBanner() {
     UIManager.dispatchViewManagerCommand(
       findNodeHandle(this._bannerView),
-      UIManager.RNDFPBannerView.Commands.loadBanner,
+      UIManager.getViewManagerConfig('RNDFPBannerView').Commands.loadBanner,
       null,
     );
   }


### PR DESCRIPTION
Fixed: Accessing view manager configs directly of UIManager via UIManager[‘***’] is no longer supported. Use UIManager.getViewManagerConfig(‘***’) instead.