### PR TITLE
Android Google Play Services ads override #379

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,6 +21,6 @@ android {
 }
 
 dependencies {
-    implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.gms:play-services-ads:+'
+    implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
+    implementation "com.google.android.gms:play-services-ads:${safeExtGet('googlePlayServicesAdsVersion', '+')}"
 }


### PR DESCRIPTION
fix for #379  

using a for "+" version for the ads version always takes latest so when combined with other libraries (eg. firebase) causes version mismatches and duplicate class errors on android.

to override the version add
```groovy
rootProject.ext.googlePlayServicesAdsVersion = "17.1.0"
```
in your build.gradle (android/build.gradle)
you will probably need to figure out the correct version you need 
check the versions here:
https://mvnrepository.com/artifact/com.google.android.gms/play-services-ads
