### PR TITLE
WIP: Native Ad Support

### DIFF
--- a/RNAdMobNative.js
+++ b/RNAdMobNative.js
@@ -1,0 +1,102 @@
+import { arrayOf, func, string } from 'prop-types';
+import React, { Component } from 'react';
+import {
+  findNodeHandle,
+  requireNativeComponent,
+  UIManager,
+  ViewPropTypes,
+} from 'react-native';
+import { createErrorFromErrorData } from './utils';
+
+class RNAdMobNative extends Component {
+  constructor() {
+    super();
+    this.handleAdFailedToLoad = this.handleAdFailedToLoad.bind(this);
+    this.state = {
+      style: {},
+    };
+  }
+
+  componentDidMount() {
+    const { adUnitId } = this.props;
+    if (adUnitId) {
+      return this.loadNativeAd(adUnitId);
+    }
+    console.warn('Attempted to load native ad without ad unit id');
+  }
+
+  loadNativeAd(adUnitId) {
+    UIManager.dispatchViewManagerCommand(
+      findNodeHandle(this._nativeView),
+      UIManager.getViewManagerConfig('RNGADNativeView').Commands.loadNativeAd,
+      [adUnitId]
+    );
+  }
+
+  handleAdFailedToLoad(event) {
+    if (this.props.onAdFailedToLoad) {
+      this.props.onAdFailedToLoad(
+        createErrorFromErrorData(event.nativeEvent.error)
+      );
+    }
+  }
+
+  setRef = (el) => (this._nativeView = el);
+
+  render() {
+    return (
+      <RNGADNativeView
+        {...this.props}
+        style={[this.props.style, this.state.style]}
+        onAdFailedToLoad={this.handleAdFailedToLoad}
+        ref={this.setRef}
+      />
+    );
+  }
+}
+
+RNAdMobNative.simulatorId = 'SIMULATOR';
+
+RNAdMobNative.propTypes = {
+  ...ViewPropTypes,
+
+  /**
+   * Google AdMob templates are being used to display native ads
+   * (https://developers.google.com/admob/ios/native/templates)
+   * Two sizes are available; medium and small
+   *
+   * small is default
+   */
+  adSize: string,
+
+  /**
+   * AdMob ad unit ID
+   */
+  adUnitID: string,
+
+  /**
+   * Array of test devices. Use AdMobBanner.simulatorId for the simulator
+   */
+  testDevices: arrayOf(string),
+
+  /**
+   * GADUnifiedNativeAdDelegate lifecycle methods
+   * https://developers.google.com/ad-manager/mobile-ads-sdk/ios/api/reference/Protocols/GADUnifiedNativeAdDelegate
+   */
+  onAdOpened: func,
+  onAdClosed: func,
+  onAdLeftApplication: func,
+  didRecordImpression: func,
+  didRecordClick: func,
+
+  /**
+   * GADUnifiedNativeAdLoaderDelegate
+   * https://developers.google.com/ad-manager/mobile-ads-sdk/ios/api/reference/Protocols/GADUnifiedNativeAdLoaderDelegate
+   */
+  onAdLoaded: func,
+  onAdFailedToLoad: func,
+};
+
+const RNGADNativeView = requireNativeComponent('RNGADNativeView', RNAdMobNative);
+
+export default RNAdMobNative;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 /* eslint-disable global-require */
 module.exports = {
+  get AdMobNative() {
+    return require('./RNAdMobNative').default;
+  },
   get AdMobBanner() {
     return require('./RNAdMobBanner').default;
   },

--- a/ios/GADTMediumTemplateView.h
+++ b/ios/GADTMediumTemplateView.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GADTTemplateView.h"
+
+/// A template for medium sized views. Renders a roughly square view with a call to action on the
+/// bottom and a horizontal image in the middle.
+@interface GADTMediumTemplateView : GADTTemplateView
+
+@end

--- a/ios/GADTMediumTemplateView.m
+++ b/ios/GADTMediumTemplateView.m
@@ -1,0 +1,30 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#import "GADTMediumTemplateView.h"
+
+@implementation GADTMediumTemplateView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+  }
+  return self;
+}
+
+
+- (NSString *)getTemplateTypeName {
+  return @"medium_template";
+}
+
+@end

--- a/ios/GADTSmallTemplateView.h
+++ b/ios/GADTSmallTemplateView.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "GADTTemplateView.h"
+
+/// A small template, perfect for UITableViewCells or other row views.
+@interface GADTSmallTemplateView : GADTTemplateView
+
+@end

--- a/ios/GADTSmallTemplateView.m
+++ b/ios/GADTSmallTemplateView.m
@@ -1,0 +1,30 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#import "GADTSmallTemplateView.h"
+
+@implementation GADTSmallTemplateView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+    self.translatesAutoresizingMaskIntoConstraints = NO;
+  }
+  return self;
+}
+
+- (NSString *)getTemplateTypeName {
+  return @"small_template";
+}
+
+@end

--- a/ios/GADTTemplateView.h
+++ b/ios/GADTTemplateView.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//  Copyright © 2018 Google. All rights reserved.
+
+#import <GoogleMobileAds/GoogleMobileAds.h>
+
+/// Constants used to style your template.
+typedef NSString* GADTNativeTemplateStyleKey NS_STRING_ENUM;
+
+/// The font, font color and background color for your call to action view.
+/// All templates have a call to action view.
+#pragma mark - Call To Action
+
+/// Call to action font. Expects a UIFont.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCallToActionFont;
+
+/// Call to action font color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCallToActionFontColor;
+
+/// Call to action background color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCallToActionBackgroundColor;
+
+/// The font, font color and background color for the first row of text in the template.
+/// All templates have a primary text area which is populated by the native ad's headline.
+#pragma mark - Primary Text
+
+/// Primary text font. Expects a UIFont.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyPrimaryFont;
+
+/// Primary text font color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyPrimaryFontColor;
+
+/// Primary text background color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyPrimaryBackgroundColor;
+
+/// The font, font color and background color for the second row of text in the template.
+/// All templates have a secondary text area which is populated either by the body of the ad,
+/// or by the rating of the app.
+#pragma mark - Secondary Text
+
+/// Secondary text font. Expects a UIFont.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeySecondaryFont;
+
+/// Secondary text font color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeySecondaryFontColor;
+
+/// Secondary text background color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeySecondaryBackgroundColor;
+
+/// The font, font color and background color for the third row of text in the template.
+/// The third row is used to display store name or the default tertiary text.
+#pragma mark - Tertiary Text
+
+/// Tertiary text font. Expects a UIFont.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyTertiaryFont;
+
+/// Tertiary text font color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyTertiaryFontColor;
+
+/// Tertiary text background color. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyTertiaryBackgroundColor;
+
+#pragma mark - Additional Style Options
+
+/// The background color for the bulk of the ad. Expects a UIColor.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyMainBackgroundColor;
+
+/// The corner rounding radius for the icon view and call to action. Expects an NSNumber.
+extern GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCornerRadius;
+
+/// The super class for every template object.
+/// This class has the majority of all layout and styling logic.
+@interface GADTTemplateView : GADUnifiedNativeAdView
+@property(nonatomic, copy) NSDictionary<GADTNativeTemplateStyleKey, NSObject*>* styles;
+@property(weak) IBOutlet UILabel* primaryTextView;
+@property(weak) IBOutlet UILabel* secondaryTextView;
+@property(weak) IBOutlet UILabel* tertiaryTextView;
+@property(weak) IBOutlet UILabel* adBadge;
+@property(weak) IBOutlet UIImageView* brandImage;
+@property(weak) IBOutlet UIView* backgroundView;
+@property(weak) UIView* rootView;
+
+/// Adds a constraint to the superview so that the template spans the width of its parent.
+/// Does nothing if there is no superview.
+- (void)addHorizontalConstraintsToSuperviewWidth;
+
+/// Adds a constraint to the superview so that the template is centered vertically in its parent.
+/// Does nothing if there is no superview.
+- (void)addVerticalCenterConstraintToSuperview;
+
+/// Utility method to get a color from a hex string.
++ (UIColor*)colorFromHexString:(NSString*)hexString;
+
+- (NSString *)getTemplateTypeName;
+@end

--- a/ios/GADTTemplateView.m
+++ b/ios/GADTTemplateView.m
@@ -1,0 +1,306 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//  Copyright © 2018 Google. All rights reserved.
+
+#import "GADTTemplateView.h"
+#import <QuartzCore/QuartzCore.h>
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCallToActionFont =
+    @"call_to_action_font";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCallToActionFontColor =
+    @"call_to_action_font_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCallToActionBackgroundColor =
+    @"call_to_action_background_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeySecondaryFont = @"secondary_font";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeySecondaryFontColor =
+    @"secondary_font_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeySecondaryBackgroundColor =
+    @"secondary_background_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyPrimaryFont = @"primary_font";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyPrimaryFontColor = @"primary_font_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyPrimaryBackgroundColor =
+    @"primary_background_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyTertiaryFont = @"tertiary_font";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyTertiaryFontColor =
+    @"tertiary_font_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyTertiaryBackgroundColor =
+    @"tertiary_background_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyMainBackgroundColor =
+    @"main_background_color";
+
+GADTNativeTemplateStyleKey const GADTNativeTemplateStyleKeyCornerRadius = @"corner_radius";
+
+static NSString* const GADTBlue = @"#5C84F0";
+
+@implementation GADTTemplateView {
+  NSDictionary<GADTNativeTemplateStyleKey, NSObject*>* _defaultStyles;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  if (self = [super initWithFrame:frame]) {
+
+
+    _rootView = [NSBundle.mainBundle loadNibNamed:NSStringFromClass([self class])
+                                            owner:self
+                                          options:nil]
+                    .firstObject;
+
+    [self addSubview:_rootView];
+
+    [self
+        addConstraints:[NSLayoutConstraint
+                           constraintsWithVisualFormat:@"H:|[_rootView]|"
+                                               options:0
+                                               metrics:nil
+                                                 views:NSDictionaryOfVariableBindings(_rootView)]];
+    [self
+        addConstraints:[NSLayoutConstraint
+                           constraintsWithVisualFormat:@"V:|[_rootView]|"
+                                               options:0
+                                               metrics:nil
+                                                 views:NSDictionaryOfVariableBindings(_rootView)]];
+    [self applyStyles];
+    [self styleAdBadge];
+  }
+  return self;
+}
+
+- (NSString *)getTemplateTypeName {
+  return @"root";
+}
+
+/// Returns the style value for the provided key or the default style if no styles dictionary
+/// was set.
+- (id)styleForKey:(GADTNativeTemplateStyleKey)key {
+  return _styles[key] ?: nil;
+}
+
+// Goes through all recognized style keys and updates the views accordingly, overwriting the
+// defaults.
+- (void)applyStyles {
+  self.layer.borderColor = [GADTTemplateView colorFromHexString:@"E0E0E0"].CGColor;
+  self.layer.borderWidth = 1.0f;
+  [self.mediaView sizeToFit];
+  if ([self styleForKey:GADTNativeTemplateStyleKeyCornerRadius]) {
+    float roundedCornerRadius =
+    ((NSNumber*)[self styleForKey:GADTNativeTemplateStyleKeyCornerRadius]).floatValue;
+    
+    // Rounded corners
+    self.iconView.layer.cornerRadius = roundedCornerRadius;
+    self.iconView.clipsToBounds = YES;
+    ((UIButton*)self.callToActionView).layer.cornerRadius = roundedCornerRadius;
+    ((UIButton*)self.callToActionView).clipsToBounds = YES;
+  }
+
+  // Fonts
+  if ([self styleForKey:GADTNativeTemplateStyleKeyPrimaryFont]) {
+    ((UILabel*)_primaryTextView).font =
+    (UIFont*)[self styleForKey:GADTNativeTemplateStyleKeyPrimaryFont];
+  }
+ 
+  if ([self styleForKey:GADTNativeTemplateStyleKeySecondaryFont]) {
+    ((UILabel*)_secondaryTextView).font =
+    (UIFont*)[self styleForKey:GADTNativeTemplateStyleKeySecondaryFont];
+  }
+  
+  if ([self styleForKey:GADTNativeTemplateStyleKeyTertiaryFont]) {
+    ((UILabel*)_tertiaryTextView).font =
+    (UIFont*)[self styleForKey:GADTNativeTemplateStyleKeyTertiaryFont];
+  }
+
+  if ([self styleForKey:GADTNativeTemplateStyleKeyCallToActionFont]) {
+    ((UIButton*)self.callToActionView).titleLabel.font =
+    (UIFont*)[self styleForKey:GADTNativeTemplateStyleKeyCallToActionFont];
+  }
+  
+  // Font colors
+  if ([self styleForKey:GADTNativeTemplateStyleKeyPrimaryFontColor])
+  ((UILabel*)_primaryTextView).textColor =
+      (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyPrimaryFontColor];
+  
+  if ([self styleForKey:GADTNativeTemplateStyleKeySecondaryFontColor]) {
+    ((UILabel*)_secondaryTextView).textColor =
+    (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeySecondaryFontColor];
+  }
+
+  if ([self styleForKey:GADTNativeTemplateStyleKeyTertiaryFontColor]) {
+    ((UILabel*)_tertiaryTextView).textColor =
+    (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyTertiaryFontColor];
+  }
+ 
+  if ([self styleForKey:GADTNativeTemplateStyleKeyCallToActionFontColor]) {
+    [((UIButton*)self.callToActionView)
+     setTitleColor:(UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyCallToActionFontColor]
+     forState:UIControlStateNormal];
+  }
+
+  // Background colors
+  if ([self styleForKey:GADTNativeTemplateStyleKeyPrimaryBackgroundColor]) {
+    ((UILabel*)_primaryTextView).backgroundColor =
+    (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyPrimaryBackgroundColor];
+  }
+  
+  if ([self styleForKey:GADTNativeTemplateStyleKeySecondaryBackgroundColor]) {
+    ((UILabel*)_secondaryTextView).backgroundColor =
+    (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeySecondaryBackgroundColor];
+
+  }
+  
+  if ([self styleForKey:GADTNativeTemplateStyleKeyTertiaryBackgroundColor]) {
+    ((UILabel*)_tertiaryTextView).backgroundColor =
+    (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyTertiaryBackgroundColor];
+  }
+  
+  if ([self styleForKey:GADTNativeTemplateStyleKeyCallToActionBackgroundColor]) {
+    ((UIButton*)self.callToActionView).backgroundColor =
+    (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyCallToActionBackgroundColor];
+  }
+  
+  if ([self styleForKey:GADTNativeTemplateStyleKeyMainBackgroundColor]) {
+    self.backgroundColor = (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyMainBackgroundColor];
+  }
+  
+  if (_backgroundView && [self styleForKey:GADTNativeTemplateStyleKeyPrimaryBackgroundColor]) {
+    _backgroundView.backgroundColor =
+    (UIColor*)[self styleForKey:GADTNativeTemplateStyleKeyPrimaryBackgroundColor];
+  }
+ 
+}
+
+/// Styles the Ad Badge according to best practices.
+- (void)styleAdBadge {
+  _adBadge.layer.borderColor = _adBadge.textColor.CGColor;
+  _adBadge.layer.borderWidth = 1.0;
+  _adBadge.layer.cornerRadius = 3.0;
+}
+
+- (void)setStyles:(NSDictionary<GADTNativeTemplateStyleKey, NSObject*>*)styles {
+  _styles = [styles copy];
+  [self applyStyles];
+}
+
+- (void)setNativeAd:(GADUnifiedNativeAd*)nativeAd {
+  [super setNativeAd:nativeAd];
+  self.headlineView = _primaryTextView;
+  NSString* adBody = nativeAd.body;
+  NSString* cta = nativeAd.callToAction;
+  NSString* headline = nativeAd.headline;
+  NSString* tertiaryText;
+
+  if (nativeAd.store.length && !nativeAd.advertiser.length) {
+    // Ad has store but not advertiser
+    self.storeView = _tertiaryTextView;
+    tertiaryText = nativeAd.store;
+  } else if (!nativeAd.store.length && nativeAd.advertiser.length) {
+    // Ad has advertiser but not store
+    self.advertiserView = _tertiaryTextView;
+    tertiaryText = nativeAd.advertiser;
+  } else if (!nativeAd.store.length && !nativeAd.advertiser.length) {
+    // Ad has both store and advertiser, default to showing advertiser.
+    self.advertiserView = _tertiaryTextView;
+    tertiaryText = nativeAd.advertiser;
+  }
+
+  ((UILabel*)_primaryTextView).text = headline;
+  ((UILabel*)_tertiaryTextView).text = tertiaryText;
+  [((UIButton*)self.callToActionView) setTitle:cta forState:UIControlStateNormal];
+  // Body text
+  // We either show the number of stars an app has, or show the body of the ad.
+  // Use the unicode characters for filled in or empty stars.
+  if (nativeAd.starRating.floatValue > 0) {
+    NSMutableString* stars = [[NSMutableString alloc] initWithString:@""];
+    int count = 0;
+    for (; count < nativeAd.starRating.intValue; count++) {
+      NSString* filledStar = [NSString stringWithUTF8String:"\u2605"];
+      [stars appendString:filledStar];
+    }
+    for (; count < 5; count++) {
+      NSString* emptyStar = [NSString stringWithUTF8String:"\u2606"];
+      [stars appendString:emptyStar];
+    }
+    adBody = stars;
+    self.starRatingView = _secondaryTextView;
+  } else {
+    self.bodyView = _secondaryTextView;
+  }
+
+  ((UILabel*)_secondaryTextView).text = adBody;
+  
+  if (nativeAd.icon) {
+    ((UIImageView*)self.iconView).image = nativeAd.icon.image;
+  } 
+  [self.mediaView setMediaContent:nativeAd.mediaContent];
+  
+}
+
+- (void)addHorizontalConstraintsToSuperviewWidth {
+  // Add an autolayout constraint to make sure our template view stretches to fill the
+  // width of its parent.
+  if (self.superview) {
+    UIView* child = self;
+    [self.superview
+     addConstraints:[NSLayoutConstraint
+                     constraintsWithVisualFormat:@"H:|[child]|"
+                     options:0
+                     metrics:nil
+                     views:NSDictionaryOfVariableBindings(child)]];
+  }
+}
+
+- (void)addVerticalCenterConstraintToSuperview {
+  if (self.superview) {
+    UIView* child = self;
+    [self.superview addConstraint:[NSLayoutConstraint constraintWithItem:self.superview
+                                                               attribute:NSLayoutAttributeCenterY
+                                                               relatedBy:NSLayoutRelationEqual
+                                                                  toItem:child
+                                                               attribute:NSLayoutAttributeCenterY
+                                                              multiplier:1
+                                                                constant:0]];
+  }
+}
+
+/// Creates an opaque UIColor object from a byte-value color definition.
++ (UIColor*)colorFromHexString:(NSString*)hexString {
+  if (hexString == nil) {
+    return nil;
+  }
+  NSRange range = [hexString rangeOfString:@"^#[0-9a-fA-F]{6}$" options:NSRegularExpressionSearch];
+  if (range.location == NSNotFound) {
+    return nil;
+  }
+  unsigned rgbValue = 0;
+  NSScanner* scanner = [NSScanner scannerWithString:hexString];
+  [scanner setScanLocation:1];  // Bypass '#' character.
+  [scanner scanHexInt:&rgbValue];
+
+  return [UIColor colorWithRed:((rgbValue & 0xff0000) >> 16) / 255.0f
+                         green:((rgbValue & 0xff00) >> 8) / 255.0f
+                          blue:(rgbValue & 0xff) / 255.0f
+                         alpha:1];
+}
+@end

--- a/ios/RNAdMobManager.xcodeproj/project.pbxproj
+++ b/ios/RNAdMobManager.xcodeproj/project.pbxproj
@@ -15,6 +15,12 @@
 		A962C2531CB27DBD00E508A1 /* RNAdMobInterstitial.m in Sources */ = {isa = PBXBuildFile; fileRef = A962C2521CB27DBD00E508A1 /* RNAdMobInterstitial.m */; };
 		A96DA7841C146DA600FC639B /* RNGADBannerView.m in Sources */ = {isa = PBXBuildFile; fileRef = A96DA7811C146DA600FC639B /* RNGADBannerView.m */; };
 		A96DA7851C146DA600FC639B /* RNGADBannerViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = A96DA7831C146DA600FC639B /* RNGADBannerViewManager.m */; };
+		F90A723223E90755001A979C /* RNGADNativeView.m in Sources */ = {isa = PBXBuildFile; fileRef = F90A723123E90755001A979C /* RNGADNativeView.m */; };
+		F90A723623E91B31001A979C /* RNGADNativeViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F90A723523E91B31001A979C /* RNGADNativeViewManager.m */; };
+		F9599ADF23EA2C95007601E8 /* GADTSmallTemplateView.m in Sources */ = {isa = PBXBuildFile; fileRef = F9599AD923EA2C95007601E8 /* GADTSmallTemplateView.m */; };
+		F9599AE023EA2C95007601E8 /* GADTMediumTemplateView.m in Sources */ = {isa = PBXBuildFile; fileRef = F9599ADA23EA2C95007601E8 /* GADTMediumTemplateView.m */; };
+		F9599AE123EA2C95007601E8 /* GADTTemplateView.m in Sources */ = {isa = PBXBuildFile; fileRef = F9599ADD23EA2C95007601E8 /* GADTTemplateView.m */; };
+		F9FEA62523E973F700D2A1C7 /* GoogleMobileAds.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F9FEA62423E973F700D2A1C7 /* GoogleMobileAds.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -47,6 +53,17 @@
 		A96DA7811C146DA600FC639B /* RNGADBannerView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGADBannerView.m; sourceTree = SOURCE_ROOT; };
 		A96DA7821C146DA600FC639B /* RNGADBannerViewManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNGADBannerViewManager.h; sourceTree = SOURCE_ROOT; };
 		A96DA7831C146DA600FC639B /* RNGADBannerViewManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNGADBannerViewManager.m; sourceTree = SOURCE_ROOT; };
+		F90A723123E90755001A979C /* RNGADNativeView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNGADNativeView.m; sourceTree = SOURCE_ROOT; };
+		F90A723323E90762001A979C /* RNGADNativeView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNGADNativeView.h; sourceTree = SOURCE_ROOT; };
+		F90A723423E91B19001A979C /* RNGADNativeViewManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNGADNativeViewManager.h; sourceTree = SOURCE_ROOT; };
+		F90A723523E91B31001A979C /* RNGADNativeViewManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RNGADNativeViewManager.m; sourceTree = SOURCE_ROOT; };
+		F9599AD923EA2C95007601E8 /* GADTSmallTemplateView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADTSmallTemplateView.m; sourceTree = SOURCE_ROOT; };
+		F9599ADA23EA2C95007601E8 /* GADTMediumTemplateView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADTMediumTemplateView.m; sourceTree = SOURCE_ROOT; };
+		F9599ADB23EA2C95007601E8 /* GADTTemplateView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADTTemplateView.h; sourceTree = SOURCE_ROOT; };
+		F9599ADC23EA2C95007601E8 /* GADTMediumTemplateView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADTMediumTemplateView.h; sourceTree = SOURCE_ROOT; };
+		F9599ADD23EA2C95007601E8 /* GADTTemplateView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GADTTemplateView.m; sourceTree = SOURCE_ROOT; };
+		F9599ADE23EA2C95007601E8 /* GADTSmallTemplateView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GADTSmallTemplateView.h; sourceTree = SOURCE_ROOT; };
+		F9FEA62423E973F700D2A1C7 /* GoogleMobileAds.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GoogleMobileAds.framework; path = "../../../../Downloads/GoogleMobileAdsSdkiOS-7.54.0/GoogleMobileAds.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,6 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F9FEA62523E973F700D2A1C7 /* GoogleMobileAds.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,6 +83,7 @@
 			children = (
 				A96DA7761C146D7200FC639B /* RNAdMobManager */,
 				A96DA7751C146D7200FC639B /* Products */,
+				F9FEA62323E973F700D2A1C7 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -79,6 +98,12 @@
 		A96DA7761C146D7200FC639B /* RNAdMobManager */ = {
 			isa = PBXGroup;
 			children = (
+				F9599ADC23EA2C95007601E8 /* GADTMediumTemplateView.h */,
+				F9599ADA23EA2C95007601E8 /* GADTMediumTemplateView.m */,
+				F9599ADE23EA2C95007601E8 /* GADTSmallTemplateView.h */,
+				F9599AD923EA2C95007601E8 /* GADTSmallTemplateView.m */,
+				F9599ADB23EA2C95007601E8 /* GADTTemplateView.h */,
+				F9599ADD23EA2C95007601E8 /* GADTTemplateView.m */,
 				0CB8C04C1D9143A6002BC3EF /* RNDFPBannerViewManager.h */,
 				0CB8C04D1D9143A6002BC3EF /* RNDFPBannerViewManager.m */,
 				A96DA7801C146DA600FC639B /* RNGADBannerView.h */,
@@ -95,8 +120,20 @@
 				A90F2F8B1D50AEF200F2A2E3 /* RNAdMobRewarded.m */,
 				5E86A6451F126FCE008013EB /* RCTConvert+GADAdSize.h */,
 				5E86A6461F126FCE008013EB /* RCTConvert+GADAdSize.m */,
+				F90A723323E90762001A979C /* RNGADNativeView.h */,
+				F90A723123E90755001A979C /* RNGADNativeView.m */,
+				F90A723423E91B19001A979C /* RNGADNativeViewManager.h */,
+				F90A723523E91B31001A979C /* RNGADNativeViewManager.m */,
 			);
 			path = RNAdMobManager;
+			sourceTree = "<group>";
+		};
+		F9FEA62323E973F700D2A1C7 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F9FEA62423E973F700D2A1C7 /* GoogleMobileAds.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -109,6 +146,7 @@
 				A96DA7701C146D7200FC639B /* Sources */,
 				A96DA7711C146D7200FC639B /* Frameworks */,
 				A96DA7721C146D7200FC639B /* CopyFiles */,
+				F9D5777923E9363800EF2384 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -139,6 +177,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = A96DA76B1C146D7200FC639B;
@@ -151,6 +190,16 @@
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		F9D5777923E9363800EF2384 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		A96DA7701C146D7200FC639B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -158,9 +207,14 @@
 			files = (
 				A962C2531CB27DBD00E508A1 /* RNAdMobInterstitial.m in Sources */,
 				0CB8C04B1D913E00002BC3EF /* RNDFPBannerView.m in Sources */,
+				F90A723223E90755001A979C /* RNGADNativeView.m in Sources */,
+				F9599AE023EA2C95007601E8 /* GADTMediumTemplateView.m in Sources */,
 				A90F2F8C1D50AEF200F2A2E3 /* RNAdMobRewarded.m in Sources */,
 				A96DA7841C146DA600FC639B /* RNGADBannerView.m in Sources */,
+				F9599ADF23EA2C95007601E8 /* GADTSmallTemplateView.m in Sources */,
+				F9599AE123EA2C95007601E8 /* GADTTemplateView.m in Sources */,
 				A96DA7851C146DA600FC639B /* RNGADBannerViewManager.m in Sources */,
+				F90A723623E91B31001A979C /* RNGADNativeViewManager.m in Sources */,
 				5E2419841FE11E0F00C6B738 /* RNAdMobUtils.m in Sources */,
 				5E86A6471F126FCE008013EB /* RCTConvert+GADAdSize.m in Sources */,
 				0CB8C04E1D9143A6002BC3EF /* RNDFPBannerViewManager.m in Sources */,

--- a/ios/RNGADNativeView.h
+++ b/ios/RNGADNativeView.h
@@ -1,0 +1,24 @@
+#import <React/RCTView.h>
+
+@import GoogleMobileAds;
+
+@interface RNGADNativeView : RCTView <GADUnifiedNativeAdLoaderDelegate,
+    GADUnifiedNativeAdDelegate>
+
+@property(nonatomic, strong) GADUnifiedNativeAd *nativeAdView;
+@property(nonatomic, strong) GADAdLoader *adLoader;
+
+@property (nonatomic, copy) NSArray *testDevices;
+@property (nonatomic, copy) NSString *adSize;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onAdLoaded;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdFailedToLoad;
+@property (nonatomic, copy) RCTBubblingEventBlock didRecordImpression;
+@property (nonatomic, copy) RCTBubblingEventBlock didRecordClick;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdOpened;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdClosed;
+@property (nonatomic, copy) RCTBubblingEventBlock onAdLeftApplication;
+
+- (void)loadNativeAd:(NSString *)adUnitId;
+
+@end

--- a/ios/RNGADNativeView.m
+++ b/ios/RNGADNativeView.m
@@ -1,0 +1,113 @@
+
+#import "RNGADNativeView.h"
+#import "RNAdMobUtils.h"
+#import "GADTMediumTemplateView.h"
+#import "GADTSmallTemplateView.h"
+#import <React/RCTBridge.h>
+#import <React/RCTRootView.h>
+#import <React/RCTRootViewDelegate.h>
+#import <React/RCTViewManager.h>
+
+@import GoogleMobileAds;
+
+
+@implementation RNGADNativeView
+
+- (void)setAdSize:(NSString *)adSize
+{
+    NSLog(@"Setting ad size %@", adSize);
+    _adSize = adSize;
+}
+
+- (void)setTestDevices:(NSArray *)testDevices
+{
+    _testDevices = RNAdMobProcessTestDevices(testDevices, kDFPSimulatorID);
+}
+
+- (void)loadNativeAd:(NSString *)adUnitId
+{
+    UIWindow *keyWindow = [[UIApplication sharedApplication] keyWindow];
+    UIViewController *rootViewController = [keyWindow rootViewController];
+    self.adLoader = [[GADAdLoader alloc]
+            initWithAdUnitID:adUnitId
+            rootViewController:rootViewController
+            adTypes:@[ kGADAdLoaderAdTypeUnifiedNative ]
+            options:nil];
+
+    self.adLoader.delegate = self;
+    GADRequest *request = [GADRequest request];
+    GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers = _testDevices;
+    [self.adLoader loadRequest:request];
+}
+
+- (void)adLoader:(GADAdLoader *)adLoader didFailToReceiveAdWithError:(GADRequestError *)error {
+   if (self.onAdFailedToLoad) {
+       self.onAdFailedToLoad(@{ @"error": @{ @"message": [error localizedDescription] } });
+   }
+}
+
+- (void)adLoader:(GADAdLoader *)adLoader didReceiveUnifiedNativeAd:(GADUnifiedNativeAd *)nativeAd {
+    if (self.onAdLoaded) {
+        self.onAdLoaded(@{});
+    }
+    
+    if([_adSize  isEqual: @"medium"]) {
+        GADTMediumTemplateView *templateView = [[GADTMediumTemplateView alloc] init];
+        
+        nativeAd.delegate = self;
+        templateView.nativeAd = nativeAd;
+        
+        [self addSubview:templateView];
+        
+        [templateView addHorizontalConstraintsToSuperviewWidth];
+        [templateView addVerticalCenterConstraintToSuperview];
+    } else {
+        GADTSmallTemplateView *templateView = [[GADTSmallTemplateView alloc] init];
+        
+        nativeAd.delegate = self;
+        templateView.nativeAd = nativeAd;
+        
+        [self addSubview:templateView];
+        
+        [templateView addHorizontalConstraintsToSuperviewWidth];
+        [templateView addVerticalCenterConstraintToSuperview];
+    }
+}
+
+- (void)nativeAdDidRecordImpression:(nonnull GADUnifiedNativeAd *)nativeAd
+{
+    if (self.didRecordImpression) {
+        self.didRecordImpression(@{});
+    }
+}
+
+- (void)nativeAdDidRecordClick:(nonnull GADUnifiedNativeAd *)nativeAd
+{
+    if (self.didRecordClick) {
+           self.didRecordClick(@{});
+       }
+}
+
+- (void)nativeAdWillPresentScreen:(nonnull GADUnifiedNativeAd *)nativeAd
+{
+    if (self.onAdOpened) {
+        self.onAdOpened(@{});
+    }
+}
+
+- (void)nativeAdWillDismissScreen:(nonnull GADUnifiedNativeAd *)nativeAd
+{
+    if (self.onAdClosed) {
+           self.onAdClosed(@{});
+       }
+}
+
+- (void)nativeAdWillLeaveApplication:(nonnull GADUnifiedNativeAd *)nativeAd
+{
+    if(self.onAdLeftApplication) {
+        self.onAdLeftApplication(@{});
+    }
+}
+
+
+@end

--- a/ios/RNGADNativeViewManager.h
+++ b/ios/RNGADNativeViewManager.h
@@ -1,0 +1,9 @@
+#if __has_include(<React/RCTViewManager.h>)
+#import <React/RCTViewManager.h>
+#else
+#import "RCTViewManager.h"
+#endif
+
+@interface RNGADNativeViewManager : RCTViewManager
+
+@end

--- a/ios/RNGADNativeViewManager.m
+++ b/ios/RNGADNativeViewManager.m
@@ -1,0 +1,47 @@
+#import "RNGADNativeViewManager.h"
+#import "RNGADNativeView.h"
+
+#if __has_include(<React/RCTBridge.h>)
+#import <React/RCTBridge.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTEventDispatcher.h>
+#else
+#import "RCTBridge.h"
+#import "RCTUIManager.h"
+#import "RCTEventDispatcher.h"
+#endif
+
+@implementation RNGADNativeViewManager
+
+RCT_EXPORT_MODULE();
+
+-(UIView *)view
+{
+   return [RNGADNativeView new];
+}
+
+RCT_EXPORT_METHOD(loadNativeAd:(nonnull NSNumber *)reactTag:(NSString *)adUnitId)
+{
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNGADNativeView *> *viewRegistry) {
+        RNGADNativeView *view = viewRegistry[reactTag];
+        if (![view isKindOfClass:[RNGADNativeView class]]) {
+            RCTLogError(@"Invalid view returned from registry, expecting RNGADNativeView, got: %@", view);
+        } else {
+            [view loadNativeAd:adUnitId];
+        }
+    }];
+}
+
+
+RCT_EXPORT_VIEW_PROPERTY(adSize, NSString)
+RCT_EXPORT_VIEW_PROPERTY(testDevices, NSArray)
+
+RCT_EXPORT_VIEW_PROPERTY(onSizeChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAppEvent, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdLoaded, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdFailedToLoad, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdOpened, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdClosed, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onAdLeftApplication, RCTBubblingEventBlock)
+
+@end


### PR DESCRIPTION
I am building support for Google AdMob Native ads on IOS and Android. I am using Native Ad templates to display ads (https://developers.google.com/admob/ios/native/templates). There will be support for both small and medium templates

**Sample App**
Working project here https://github.com/MorganTrudeau/native-ad-sample

IOS:
IOS is currently working. I am loading ads into small and medium xib files. I could only get these nib files to load if they were included in the app's ios project and not in the react-native-ad-mob package. If anyone knows if this is possible that would be great. As it stands they must be added to the app's ios project and linked in Copy Bundle Resources.

Android:
Coming soon...

## Medium Template
![image](https://user-images.githubusercontent.com/28589416/73798587-143e0080-4768-11ea-83a2-7eee18e29bc3.png)

## Small Template
![image](https://user-images.githubusercontent.com/28589416/73798601-23bd4980-4768-11ea-9331-314814928c63.png)

