### PR TITLE
build.gradle Updated

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,12 +5,12 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 23)
-    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion safeExtGet('targetSdkVersion', 22)
+        targetSdkVersion 22
     }
     buildTypes {
         release {


### PR DESCRIPTION
This pull request contains fix for "Execution failed for task ':react-native-admob:verifyReleaseResources'." error. 

New solution for #361. Mentioned at https://github.com/sbugert/react-native-admob/issues/361#issuecomment-482791661.

"react": "16.8.3",
"react-native": "0.59.9",
"react-native-admob": "^2.0.0-beta.5"
