### PR TITLE
Fix adSize value 'leaderboard' on Android

### DIFF
--- a/android/src/main/java/com/sbugert/rnadmob/RNPublisherBannerViewManager.java
+++ b/android/src/main/java/com/sbugert/rnadmob/RNPublisherBannerViewManager.java
@@ -286,7 +286,7 @@ public class RNPublisherBannerViewManager extends ViewGroupManager<ReactPublishe
                 return AdSize.MEDIUM_RECTANGLE;
             case "fullBanner":
                 return AdSize.FULL_BANNER;
-            case "leaderBoard":
+            case "leaderboard":
                 return AdSize.LEADERBOARD;
             case "smartBannerPortrait":
                 return AdSize.SMART_BANNER;


### PR DESCRIPTION
To be consistent between iOS, Android, and library docs, adSize `leaderBoard` should be replaced with `leaderboard`.